### PR TITLE
Added gotoProvider & Enhanced autoCompletion

### DIFF
--- a/extension/src/completion/autocompletionProvider.ts
+++ b/extension/src/completion/autocompletionProvider.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 import { isCursorInDoubleQuoteExpr } from "../format/autoIndent";
+import { LispParser } from '../format/parser';
+import { Sexpression, LispAtom } from '../format/sexpression';
+import { findContainers, ElementRange } from "../format/autoIndent";
+import { webHelpContainer } from "../help/openWebHelp";
+import { activeDocuments } from '../workspace/workspaceInit';
+import { ReadonlyDocument } from '../project/readOnlyDocument';
 
 let internalLispFuncs: Array<string> = [];
 let internalDclKeys: Array<string> = [];
@@ -115,6 +121,7 @@ function getCmdAndVarsCompletionCandidates(allCandiates: string[], word: string,
 
 function getCompletionCandidates(allCandiates: string[], word: string, userInputIsUpper: boolean): Array<vscode.CompletionItem> {
     let suggestions: Array<vscode.CompletionItem> = [];
+    let platform = (os.platform() === "win32") ? "WIN" : "MAC";
     allCandiates.forEach((item) => {
         var candidate = item;
         if (userInputIsUpper)
@@ -122,9 +129,18 @@ function getCompletionCandidates(allCandiates: string[], word: string, userInput
         else
             candidate = item.toLowerCase();
 
-        if (candidate.startsWith(word)) {
-            var label = candidate;
-            const completion = new vscode.CompletionItem(label);
+        if (candidate.startsWith(word) && (platform === "WIN" || !winOnlyListFuncPrefix.find(pref => candidate.startsWith(pref)))) {
+            let label = candidate;
+            let lower = label.toLowerCase();
+            let cKind: vscode.CompletionItemKind = AutoLispKind.vsKind(AutoLispKind.Symbol);
+            if (webHelpContainer.ambiguousFunctions[lower] && webHelpContainer.ambiguousFunctions[lower][0].platforms.includes(platform)){
+                cKind = AutoLispKind.vsKind(AutoLispKind.Function);
+            } else if (webHelpContainer.functions[lower] && webHelpContainer.functions[lower].platforms.includes(platform)){
+                cKind = AutoLispKind.vsKind(AutoLispKind.Function);
+            } else if (webHelpContainer.enumerators[lower]){
+                cKind = AutoLispKind.vsKind(AutoLispKind.Enum);
+            }
+            const completion = new vscode.CompletionItem(label, cKind);
             suggestions.push(completion);
         }
     });
@@ -171,30 +187,222 @@ function getMatchingWord(document: vscode.TextDocument, position: vscode.Positio
     return [word, inputIsUpper];
 }
 
-function getLispAndDclCompletions(document: vscode.TextDocument, word: string, isupper: boolean): vscode.CompletionItem[] {
-    let currentLSPDoc = document.fileName;
-    let ext = currentLSPDoc.substring(currentLSPDoc.length - 4, currentLSPDoc.length).toUpperCase();
-    let candidatesItems = internalLispFuncs;
-    if (ext === ".DCL") {
-        candidatesItems = internalDclKeys;
-    }
-    let allSuggestions: Array<vscode.CompletionItem> = [];
-    allSuggestions = getCompletionCandidates(candidatesItems, word, isupper);
+// Made a derived enum so we can swap out the vscode.CompletionItemKind values in a single place
+// Image of most symbols: https://camo.qiitausercontent.com/fb2a29c3301ab07f8af7cfa657752bdd9a62b8ea/68747470733a2f2f71696974612d696d6167652d73746f72652e73332e61702d6e6f727468656173742d312e616d617a6f6e6177732e636f6d2f302f3138393034312f66396263613830662d333136362d643338382d386538362d3632613535313363616431332e706e67
+export enum AutoLispKind {
+    Global = vscode.CompletionItemKind.Property,
+    Local = vscode.CompletionItemKind.Variable,
+    Arg = vscode.CompletionItemKind.Value,
+    Defun = vscode.CompletionItemKind.Class,
+    Enum = vscode.CompletionItemKind.Constant,
+    Symbol = vscode.CompletionItemKind.Field,
+    Function = vscode.CompletionItemKind.Method
+}
+export namespace AutoLispKind {
+    export function vsKind(kind: AutoLispKind): vscode.CompletionItemKind { return kind as unknown as vscode.CompletionItemKind; }
+}
 
-    if (os.platform() === "win32") {
-        return allSuggestions;
+export class CompletionSymbolCollector {
+    private values: Map<string, string[]> = new Map();
+    private used: string[] = [ ];
+    private ret: vscode.CompletionItem[] = [ ];
+    private word: string = "";
+    private rooted: boolean = false;
+    private previousItems: string[] = [ ];
+    constructor(){ // uses the Enum Names as the list values so we can F2 rename them without having to hunt down string versions of them
+        this.values.set(AutoLispKind[AutoLispKind.Arg], []);
+        this.values.set(AutoLispKind[AutoLispKind.Defun], []);
+        this.values.set(AutoLispKind[AutoLispKind.Global], []);
+        this.values.set(AutoLispKind[AutoLispKind.Local], []);
+        this.values.set(AutoLispKind[AutoLispKind.Symbol], []);
     }
-    else {
-        return allSuggestions.filter(function(suggestion) {
-            for (var prefix of winOnlyListFuncPrefix) {
-                if (suggestion.label.startsWith(prefix)) {
-                    return false;
+
+    get allValues (): Map<string, string[]> { return this.values;}
+
+    private assembleResult(lst: string[], kind: vscode.CompletionItemKind){
+        const platform = (os.platform() === "win32") ? "WIN" : "MAC";
+        lst.forEach(name => {
+            const key = name.toLowerCase();
+            if (platform === "WIN" || !winOnlyListFuncPrefix.find(pref => key.startsWith(pref))){
+                if (this.used.indexOf(key) === -1 && (this.word === "" || key.startsWith(this.word))){
+                    this.ret.push(new vscode.CompletionItem(name, kind));
+                    this.used.push(key);
                 }
             }
-            return true;
         });
     }
-    return allSuggestions;
+
+    private tryAddSymbol(name: string, kind: AutoLispKind): void {
+        const ucName = name.toUpperCase();
+        if (name.indexOf(' ') === -1 && !this.values.get(AutoLispKind[kind]).find(p => p.toUpperCase() === ucName)){
+            this.values.get(AutoLispKind[kind]).push(name);
+        }
+        this.previousItems.unshift(ucName);
+    }
+
+    private traverseSexpression(sx: Sexpression): void {
+        let context: number|string = "";
+        sx.atoms.forEach(atom =>{
+            if (context !== "EXIT" && atom instanceof Sexpression){    
+                this.traverseSexpression(atom as Sexpression);
+                if (context === 2){
+                    context = 1;
+                }
+            } else if (context !== "EXIT") {                
+                const ucAtom = atom.symbol.toUpperCase();
+                if (atom.isComment() === true || atom.isLineComment() === true) { 
+                    // simply ignore all comments
+                } else if (context === "ARGS") {
+                    // collecting AutoLispKind.Arg's
+                    if (atom.symbol === "/"){
+                        context = "LOCALS";
+                        this.previousItems.unshift("/");
+                    } else if (atom.symbol === ")"){
+                        context = "";
+                        this.previousItems.unshift(")");
+                    } else {
+                        this.tryAddSymbol(atom.symbol, AutoLispKind.Arg);
+                    }
+                } else if (context === "LOCALS") { 
+                    // collecting AutoLispKind.Local's
+                    if (ucAtom === ")"){
+                        context = "";
+                        this.previousItems.unshift(")");
+                    } else {
+                        this.tryAddSymbol(atom.symbol, AutoLispKind.Local);
+                    }                    
+                } else if (context === 1) { 
+                    // collecting AutoLispKind.Global's     
+                    if (ucAtom === ")") {
+                        context = ""; // Done collecting Global Vars
+                        this.previousItems.unshift(ucAtom);
+                    } else {
+                        context = 2;
+                        this.tryAddSymbol(atom.symbol, AutoLispKind.Global);
+                    }
+                } else if (context === 2) {
+                    if (ucAtom === ")"){
+                        context = ""; // Done collecting Global Vars
+                    } else {
+                        context = 1; // should have been a primitive value (like a string or number), the next one could be another variable name
+                    }
+                    this.previousItems.unshift(ucAtom);                    
+                } else if (this.rooted && ucAtom === "DEFUN" || ucAtom === "DEFUN-Q") {
+                    context = "DEFUNCHILD"; // this is a child defun that I don't want variable data from
+                    this.previousItems.unshift(context);
+                } else if (context === "DEFUNCHILD") {
+                    context = "EXIT";
+                    this.tryAddSymbol(atom.symbol, AutoLispKind.Defun); // only collect defun name
+                } else if (!this.rooted && this.previousItems[0] && (this.previousItems[0] === "DEFUN" || this.previousItems[0] === "DEFUN-Q")) {                    
+                    this.rooted = true;                    
+                    this.tryAddSymbol(atom.symbol, AutoLispKind.Defun); // collected root (first) defun name
+                } else if (this.previousItems[1] && (this.previousItems[1] === "DEFUN" || this.previousItems[1] === "DEFUN-Q")) {
+                    context = ucAtom === "(" ? "ARGS" : ""; // this context tells us when we are collecting args or locals
+                    this.previousItems.unshift(ucAtom); // most likely a '(' but defuns aren't required to have a (arg / local) declaration space so it could be nil
+                } else if (this.previousItems[0] && this.previousItems[0] === "SETQ") {
+                    context = 2; // this context tells me I am looking for a variable declaration
+                    this.tryAddSymbol(atom.symbol, AutoLispKind.Global);
+                } else {
+                    this.previousItems.unshift(ucAtom);
+                }
+            }
+        });
+    }
+
+    load(document: vscode.TextDocument, position: vscode.Position): void {
+        // get the scope of this position  
+        let kwRegex: RegExp = /\(\s*(DEFUN|DEFUN-Q)\s+\S{1,99}(\s|\(|;)/gi;
+        let tmp = findContainers(document, position);
+        let pr1: ElementRange = tmp.containerBlockComment;
+        let pr2: ElementRange[] = tmp.containerParens;
+        let contents: string = "";
+        const containers: ElementRange[] = findContainers(document, position).containerParens;
+        for (let ci = 0; ci < containers.length; ci++) {
+            const entry: ElementRange = containers[ci];
+            const value: string = document.getText(new vscode.Range(document.positionAt(entry.startPos.offsetInDocument), document.positionAt(entry.endPos.offsetInDocument)));
+            // retrieve the string contents of the first Defun scope
+            if (value.search(kwRegex) !== -1){                
+                contents = value;
+                break;
+            }
+        }
+        // Fallback for when the typed values are not in a Defun
+        if (contents === ""){
+            contents = document.getText(new vscode.Range(document.positionAt(containers.slice(-1)[0].startPos.offsetInDocument), document.positionAt(containers.slice(-1)[0].endPos.offsetInDocument)));
+        }
+        
+        
+        // Create and load that scope into a temporary document for contextual parsing, had to add this openFromContent method to narrow the LispParser SOW
+        const tempDoc: ReadonlyDocument = ReadonlyDocument.openFromContent(contents, "autolisp");
+        const lp: LispParser = new LispParser(tempDoc);        
+        lp.tokenizeString(contents, 0); 
+        // this atoms forest should only be comprised of a single Sexpression unless
+        if (lp.atomsForest.length === 1 && lp.atomsForest[0] instanceof Sexpression){
+            this.traverseSexpression(lp.atomsForest[0] as Sexpression);
+        } else {
+            // some kind of structural document error came into play
+            debugger;
+        }
+        this.previousItems.length = 0; // cleanup the tracking mess
+
+        // quick scan any open documents for defun headers. 
+        // Note: This workspace.textDocuments array only ever contains a single document or I would of used it instead.
+        
+        activeDocuments.forEach(doc =>{
+            for (let lnum = 0; lnum < doc.lineCount; lnum++) {
+                const line: vscode.TextLine = doc.lineAt(lnum);
+                const value: string = line.text.toUpperCase();
+                if (value.search(kwRegex) !== -1){                                        
+                    let finalVal = line.text.match(kwRegex)[0].replace(/\(\s*(DEFUN|DEFUN-Q)\s+/ig, "");
+                    if (line.text.endsWith(finalVal) === false){
+                        finalVal = finalVal.slice(0, -1);
+                    }
+                    this.tryAddSymbol(finalVal, AutoLispKind.Defun);
+                }
+            }
+        });
+    }
+
+    getCollectedCompletionValuesFrom(kind: AutoLispKind, filteredBy?: string): Array<vscode.CompletionItem>{
+        this.used.length = this.ret.length = 0;
+        this.word = filteredBy ? filteredBy.toLowerCase() : "";
+        this.assembleResult(this.values.get(AutoLispKind[kind]), AutoLispKind.vsKind(AutoLispKind.Arg));
+        this.used.length = 0;
+        return this.ret;
+    }
+    
+    getCollectedCompletionValues(filteredBy?: string): Array<vscode.CompletionItem>{
+        this.used.length = this.ret.length = 0;
+        this.word = filteredBy ? filteredBy.toLowerCase() : "";
+        this.assembleResult(this.values.get(AutoLispKind[AutoLispKind.Arg]), AutoLispKind.vsKind(AutoLispKind.Arg));
+        this.assembleResult(this.values.get(AutoLispKind[AutoLispKind.Local]), AutoLispKind.vsKind(AutoLispKind.Local));
+        this.assembleResult(this.values.get(AutoLispKind[AutoLispKind.Global]), AutoLispKind.vsKind(AutoLispKind.Global));
+        this.assembleResult(this.values.get(AutoLispKind[AutoLispKind.Defun]), AutoLispKind.vsKind(AutoLispKind.Defun));
+        this.assembleResult(this.values.get(AutoLispKind[AutoLispKind.Symbol]), AutoLispKind.vsKind(AutoLispKind.Symbol));
+        if (os.platform() === "win32"){
+            Object.keys(webHelpContainer.enumerators).forEach(name => {            
+                if (this.used.indexOf(name) === -1 && name.startsWith(this.word)){
+                    this.ret.push(new vscode.CompletionItem(name, AutoLispKind.vsKind(AutoLispKind.Enum)));
+                    this.used.push(name);
+                }
+            });
+        }
+        this.used.length = 0;
+        return this.ret;
+    }
+}
+
+
+function getLispAndDclCompletions(document: vscode.TextDocument, word: string, isupper: boolean): vscode.CompletionItem[] {
+    const ext: string = document.fileName.toUpperCase().slice(-4);
+    if (ext === ".DCL") {
+        return getCompletionCandidates(internalDclKeys, word, isupper);
+    } else {
+        const vIndexer: CompletionSymbolCollector = new CompletionSymbolCollector();
+        vIndexer.load(document, vscode.window.activeTextEditor.selection.start);
+        // Moved WIN|MAC platform filtering to the CompletionCandidate getters so we aren't building and then discarding CompletionItem structures.
+        return vIndexer.getCollectedCompletionValues(word).concat(getCompletionCandidates(internalLispFuncs, word, isupper));
+    }
 }
 
 export function registerAutoCompletionProviders() {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,6 +19,7 @@ import * as DebugProviders from "./debug"
 import * as pmCmds from "./project/projectCommands"
 import * as helpCmds from './help/openWebHelp';
 import * as nls from 'vscode-nls';
+import * as workspaceInit from './workspace/workspaceInit';
 
 // The example uses the file message format.
 const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
@@ -66,6 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 	//6. register project commands
 	pmCmds.registerProjectCommands(context);
 	helpCmds.registerHelpCommands(context);
+	workspaceInit.registerWorkspaceProviders(context);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/extension/src/format/autoIndent.ts
+++ b/extension/src/format/autoIndent.ts
@@ -5,7 +5,7 @@ import * as format from './listreader';
 import { LispAtom, Sexpression, indentationForNarrowStyle } from './sexpression';
 import { CursorPosition } from './listreader';
 
-class ElementRange {
+export class ElementRange {
     constructor() {
         this.startPos = null;
         this.endPos = null;

--- a/extension/src/format/parser.ts
+++ b/extension/src/format/parser.ts
@@ -120,7 +120,7 @@ export class LispParser {
                     endPos2d = document.positionAt(endOfString.offsetInDocument);
                 }
                 else {
-                    endPos2d = selectionStartOffset + textString.length;
+                    endPos2d = selectionStartOffset + textString.length; // BUG: Doesn't produce Position Object
                 }
 
                 let stringExpr = document.getText(new vscode.Range(startPos2d, endPos2d));

--- a/extension/src/help/openWebHelp.ts
+++ b/extension/src/help/openWebHelp.ts
@@ -133,7 +133,10 @@ enum WebHelpCategory {
 	PROPGETTER = 2,
 	PROPSETTER = 3,
 	FUNCTION = 4,
-	ENUM = 5
+	ENUM = 5,
+	DCLTILE = 6,
+	DCLATT = 7,
+	EVENT = 8
 }
 
 
@@ -160,12 +163,14 @@ class WebHelpEntity {
 	category: WebHelpCategory;	
 	guid: string;
 	description: string;
+	platforms: string;
 	constructor(template: object)
 	{
 		this.category = template["category"];
 		this.description = template["description"];
 		this.guid = template["guid"];
 		this.id = template["id"];
+		this.platforms = template["platforms"];
 	}
 
 
@@ -254,7 +259,8 @@ class WebHelpDclTile extends WebHelpEntity {
 }
 
 
-// The valueType value is in the same arrangement as the functions, but the signatures were only very mildly processed and generally represent the exact official documentation.
+// The signatures were very mildly processed to remove irregularities, but mostly represent exactly what the official documentation provided.
+// The valueTypes were reigidly handled/specified by the abstraction generator
 class WebHelpDclAtt extends WebHelpEntity {	
 	valueType: WebHelpValueType;
 	signature: string;		

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -47,6 +47,12 @@ export class ReadonlyDocument implements vscode.TextDocument {
         this.isClosed = false;
     }
 
+    static openFromContent(fileContent: string, languageId: string): ReadonlyDocument {        
+        let ret = new ReadonlyDocument("tempfile");
+        ret.initialize(fileContent, languageId);
+        return ret;
+    }
+
     static open(filePath: string): ReadonlyDocument {
         if (fs.existsSync(filePath) == false) {
             return null;

--- a/extension/src/utils.ts
+++ b/extension/src/utils.ts
@@ -5,6 +5,11 @@ import * as fs from 'fs-extra';
 
 const os = require('os');
 
+// useful when building from new RegExp and incorporating a dynamic keyword as part of the search pattern.
+export function escapeRegExp(string): string {
+	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
 export function getFullDocRange(editor: vscode.TextEditor): vscode.Range {
     return editor.document.validateRange(
         new vscode.Range(

--- a/extension/src/workspace/gotoProvider.ts
+++ b/extension/src/workspace/gotoProvider.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import * as utils from '../utils';
+import { workspaceDocuments, activeDocuments } from "./workspaceInit";
+
+
+export class AutolispGoToProvider implements vscode.DefinitionProvider{
+	async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Location | vscode.Location[]> {
+		const editor: vscode.TextEditor = vscode.window.activeTextEditor;
+		let selected: string = editor.document.getText(editor.selection);	
+		// I tried using this 'addSelectionToNextFindMatch' trick, but it somehow not firing in time to trigger the event		
+		//			if (selected === "") {
+		//				await vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch');
+		//				selected = editor.document.getText(editor.selection);
+		//			}
+		// Settled on using a regex with a wide net and didn't use any (obvious) i18 vialoation characters 
+		if (selected === "") {
+			selected = editor.document.getText(editor.document.getWordRangeAtPosition(position, /\(\s*[\w\d\:\_\&\$\*\>\-]{1,99}/)).slice(1).trim();
+		}
+		return findGoToLocation(selected);
+	}
+}
+
+
+function findGoToLocation(searchFor: string): Promise<vscode.Location | vscode.Location[]> {
+	let kwRegex: RegExp = new RegExp("\\(\\s*(DEFUN|DEFUN-Q)\\s+" + utils.escapeRegExp(searchFor.toUpperCase()) + "(\\s|\\(|;)", "gi");
+	let found: Map<string, vscode.Position> = new Map();
+	// Try to find the definition in the currently opened documents
+	activeDocuments.forEach(doc =>{
+		for (let lnum = 0; lnum < doc.lineCount; lnum++) {
+			const line: vscode.TextLine = doc.lineAt(lnum);
+			const value: string = line.text.toUpperCase();
+			if (value.search(kwRegex) !== -1 && !found.has(doc.fileName)){
+				found.set(doc.fileName, new vscode.Position(lnum, value.search(kwRegex)));
+			}
+		}			
+	});
+	let keys: string[] = [...found.keys()];
+
+	// Only-If a definition was not found in the currently opened documents will it check the in-memory workspace document set
+	if (keys.length === 0){
+		workspaceDocuments.forEach(doc =>{
+			for (let lnum = 0; lnum < doc.lineCount; lnum++) {
+				const line: vscode.TextLine = doc.lineAt(lnum);
+				const value: string = line.text.toUpperCase();
+				if (value.search(kwRegex) !== -1 && !found.has(doc.fileName)){
+					found.set(doc.fileName, new vscode.Position(lnum, value.search(kwRegex)));
+				}
+			}
+		});
+	}
+
+	// return the possible definitions
+	keys = [...found.keys()];
+	if (keys.length >= 1) {		
+		const locations: vscode.Location[] = [];		
+		keys.forEach(k =>{
+			locations.push(new vscode.Location(vscode.Uri.file(k), found.get(k)));
+		});
+		return new Promise(resolve =>{ resolve(locations); });			
+	} else {
+		return;
+	}
+}

--- a/extension/src/workspace/workspaceInit.ts
+++ b/extension/src/workspace/workspaceInit.ts
@@ -1,0 +1,175 @@
+import * as vscode from 'vscode';
+import { AutolispGoToProvider } from "./gotoProvider";
+import { ReadonlyDocument } from "../project/readOnlyDocument";
+import * as fs from 'fs';
+
+
+// This variable represents un-opened *.LSP documents that we need to collect information from
+export const workspaceDocuments: Map<string, ReadonlyDocument> = new Map();
+export const activeDocuments: Map<string, vscode.TextDocument> = new Map();
+const docSelector = [ 'autolisp', 'lisp'];
+// How bad is it for me to store this context? I saw some other extensions doing this and vscode.extensions.getExtension() doesn't create a vscode.ExtensionContext
+let ctx: vscode.ExtensionContext; 
+let watcher: vscode.FileSystemWatcher;
+let gotoProvider: AutolispGoToProvider = new AutolispGoToProvider();
+
+
+// Entry point invoked by extension.ts
+export async function registerWorkspaceProviders(context: vscode.ExtensionContext) {
+	ctx = context;	
+
+	// Register GoToProvider	
+	context.subscriptions.push(vscode.languages.registerDefinitionProvider(docSelector,  gotoProvider));
+
+	
+	// Presumably, these objects are persisted until closed and this exported 'activeDocuments' variable will provide the context of what is opened
+	// that the 'vscode.workspace.textDocuments' namespace does not (currently) provide. It possibly does in vsix form, but not while debugging.
+	// Note, until a document previously opened in a prior session is actually activated, there is no way to know the document is technically open.
+	if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document &&
+		vscode.window.activeTextEditor.document.fileName.toUpperCase().slice(-4) === ".LSP") {
+		activeDocuments.set(vscode.window.activeTextEditor.document.uri.fsPath, vscode.window.activeTextEditor.document);
+	}
+
+
+	// This builds the 'workspaceDocuments' *.LSP Memory Document Set
+	// This feature does make the fair assumption that an AutoCAD machine has plenty of memory
+	// However, this was stress tested with a root workspace folder containing 10mb of *.LSP files and the memory footprint increased less than 50mb
+	vscode.workspace.findFiles("**").then((items: vscode.Uri[]) =>{
+		const activeDoc: string = [...activeDocuments.keys()][0];
+		items.forEach((fileitem: vscode.Uri) => {			
+			if (activeDoc !== fileitem.fsPath && fileitem.fsPath.toUpperCase().slice(-4) === ".LSP"){
+				workspaceDocuments.set(fileitem.fsPath, ReadonlyDocument.open(fileitem.fsPath));
+			}
+		});
+	});
+	
+	
+	// Adds a closing *.LSP document to the workspaceDocuments<ReadonlyDocument> Map and removes it from the activeDocuments<vscode.textDocument> Map
+	context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((e: vscode.TextDocument) => {
+		if (e.fileName.toUpperCase().slice(-4) === ".LSP") {
+			if (activeDocuments.has(e.uri.fsPath) === true) {
+				activeDocuments.delete(e.uri.fsPath);
+			}
+			workspaceDocuments.set(e.uri.fsPath, ReadonlyDocument.open(e.uri.fsPath));
+		}
+		cleanMemoryDocuments();
+	}));
+
+
+	// remove a newly opened *.LSP from the workspaceDocuments<ReadonlyDocument> Map because those will likely be updated and we prefer
+	// the 'vscode.textDocument' reference instead
+	context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
+		if (e.fileName.toUpperCase().slice(-4) === ".LSP") {
+			if (workspaceDocuments.has(e.uri.fsPath) === true) {
+				workspaceDocuments.delete(e.uri.fsPath);
+			}
+			activeDocuments.set(e.uri.fsPath, e);			
+		}
+		cleanMemoryDocuments();
+	}));
+	
+
+	// Shuffles an old Document reference within its currently location and removes the old reference or adds it if they changed the extension to *.LSP
+	context.subscriptions.push(vscode.workspace.onDidRenameFiles((e: vscode.FileRenameEvent) => {
+		e.files.forEach((fileitem: {oldUri: vscode.Uri, newUri: vscode.Uri}) => {
+			let handled = false;
+			if (activeDocuments.has(fileitem.oldUri.fsPath) === true) {
+				activeDocuments.set(fileitem.newUri.fsPath, activeDocuments.get(fileitem.oldUri.fsPath));
+				activeDocuments.delete(fileitem.oldUri.fsPath);
+				handled = true;
+			}			
+			if (workspaceDocuments.has(fileitem.oldUri.fsPath) === true) {
+				workspaceDocuments.set(fileitem.newUri.fsPath, workspaceDocuments.get(fileitem.oldUri.fsPath));
+				workspaceDocuments.delete(fileitem.oldUri.fsPath);
+				handled = true;
+			}
+			if (handled === false && fileitem.newUri.fsPath.toUpperCase().slice(-4) === ".LSP"){
+				workspaceDocuments.set(fileitem.newUri.fsPath, ReadonlyDocument.open(fileitem.newUri.fsPath));
+			}
+		});
+		cleanMemoryDocuments();
+	}));
+
+
+	// Reset and repopulate the Document Map's
+	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((e: vscode.WorkspaceFoldersChangeEvent) => {
+		activeDocuments.clear();
+		workspaceDocuments.clear();
+		
+		if (watcher){
+			watcher.dispose();		
+		}
+		
+		if (vscode.workspace.name) {
+			if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document &&
+				vscode.window.activeTextEditor.document.fileName.toUpperCase().slice(-4) === ".LSP"){
+				activeDocuments.set(vscode.window.activeTextEditor.document.uri.fsPath, vscode.window.activeTextEditor.document);
+			}
+	
+			vscode.workspace.findFiles("**").then((items: vscode.Uri[]) => {
+				const activeDoc: string = [...activeDocuments.keys()][0];
+				items.forEach((fileitem: vscode.Uri) => {			
+					if (activeDoc !== fileitem.fsPath && fileitem.fsPath.toUpperCase().slice(-4) === ".LSP") {
+						workspaceDocuments.set(fileitem.fsPath, ReadonlyDocument.open(fileitem.fsPath));
+					}
+				});
+			});
+			setupFileSystemWatcher();		
+		}
+	}));
+
+
+	// Needed FileSystemWatcher because the workspace events don't cover FileSystem operations outside of the Workspace Interface
+	if (vscode.workspace.name){
+		setupFileSystemWatcher();		
+	}	
+}
+
+
+
+// Neccessary to get notifications about non-workspace file additions, removals and renames. 
+function setupFileSystemWatcher(){
+	if (watcher){
+		watcher.dispose();		
+	}
+
+	const pattern = new vscode.RelativePattern(vscode.workspace.workspaceFolders[0], "**");
+	watcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false);
+
+	ctx.subscriptions.push(watcher.onDidDelete((e: vscode.Uri) => {		
+		if (activeDocuments.has(e.fsPath) === true) {
+			activeDocuments.delete(e.fsPath);
+		}
+		if (workspaceDocuments.has(e.fsPath) === true) {
+			workspaceDocuments.delete(e.fsPath);
+		}		
+	}));
+
+	ctx.subscriptions.push(watcher.onDidCreate((e: vscode.Uri) => {
+		if (e.fsPath.toUpperCase().slice(-4) === ".LSP"){
+			if (workspaceDocuments.has(e.fsPath) === false) {
+				workspaceDocuments.set(e.fsPath, ReadonlyDocument.open(e.fsPath));
+			}
+			cleanMemoryDocuments();
+		}
+	}));
+}
+
+
+export function cleanMemoryDocuments() {	
+	let keys = [...activeDocuments.keys()];
+	keys.forEach(k => {
+		if (workspaceDocuments.has(k) === true) {
+			workspaceDocuments.delete(k);
+		}
+		if (fs.existsSync(k) === false) {
+			activeDocuments.delete(k);
+		}
+	});
+	keys = [...workspaceDocuments.keys()];
+	keys.forEach(k => {
+		if (fs.existsSync(k) === false) {
+			workspaceDocuments.delete(k);
+		}
+	});
+}


### PR DESCRIPTION
I still have some further testing to do with this, but I'd rather get the review process going before I am too far down a rabbit hole. There are some things that could potentially be considered sketchy, but some effort was made to mitigate the potential problems too. Either way, I should really get the course correction now if its necessary.

**Note:** Do try to think about future benefits of using this to provide inline argument signatures for user defined functions.
- If a workspace is open, this will load every LSP into memory for quick referencing. I've tested this with 10MB of LSP's and it only bumps the memory footprint by less than 50mb. I figured on a CAD machine that's nothing and 10mb isn't realistic for most folks. What this does is make GoToDefinitionProvider (F12) nearly instantaneous across the whole workspace. All of this memory-document loading seems to be happening passively without any locking of VSCode.
- Adds workspace file management to account for all these memory-only documents. Some of this is in the form of vscode.workspace.events, but some had to come from a FileSystemWatcher because the workspace events only fire from direct input on the workspace interface.
- Enhanced the AutoCompletionProvider to use diverse symbols in its results to identify
   - Global Variables (contextual to current defun)
   - Argument Variables (contextual to current defun)
   - Localized Variables (contextual to current defun)
   - Functions (Documented; contextual to the ./data/ text files & the webHelpAbstraction.json)
   - Functions (Undocumented; contextual only to the ./data/ text files)
   - Function (User-Defined; contextual to all opened/previously activated LSP's)
   - Enumerations (Windows Only and probably won't keep it. This probably only makes sense when inline-function specific context is implemented for the webHelpAbstraction signatures and the enum suggestions can be narrowed down to what is possible)
