### PR TITLE
PRJ Treeview, ProjectNode & LspFileNode Updates

### DIFF
--- a/extension/src/project/projectCommands.ts
+++ b/extension/src/project/projectCommands.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode'
+import * as vscode from 'vscode';
 import { OpenProject } from './openProject';
 import { ProjectTreeProvider } from './projectTree';
 import { openLspFile } from './openLspFile';
@@ -62,6 +62,22 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                     let msg = localize("autolispext.project.commands.openprojectfailed", "Failed to open the specified project.");
                     showErrorMessage(msg, err);
                 });
+        }));
+
+        context.subscriptions.push(vscode.commands.registerCommand('autolisp.closeProject', async () => {
+            try {
+                let promptmsg = localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
+                let responseYes = localize("autolispext.project.commands.closepromptyes", "Yes");
+                let responseNo = localize("autolispext.project.commands.closepromptno", "No");
+                vscode.window.showWarningMessage(promptmsg + ProjectTreeProvider.instance().projectNode.projectName, responseYes, responseNo).then(result => {
+                    if (result === responseYes){
+                        ProjectTreeProvider.closeProject();
+                    }
+                });
+            } catch (err) {
+                let msg = localize("autolispext.project.commands.closefailed", "Failed to close project.");
+                showErrorMessage(msg, err);
+            }
         }));
 
         context.subscriptions.push(vscode.commands.registerCommand('autolisp.addFile2Project', async () => {

--- a/extension/src/project/projectCommands.ts
+++ b/extension/src/project/projectCommands.ts
@@ -65,18 +65,15 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         }));
 
         context.subscriptions.push(vscode.commands.registerCommand('autolisp.closeProject', async () => {
-            try {
+            if (ProjectTreeProvider.hasProjectOpened() === true){
                 let promptmsg = localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
                 let responseYes = localize("autolispext.project.commands.closepromptyes", "Yes");
                 let responseNo = localize("autolispext.project.commands.closepromptno", "No");
                 vscode.window.showWarningMessage(promptmsg + ProjectTreeProvider.instance().projectNode.projectName, responseYes, responseNo).then(result => {
                     if (result === responseYes){
-                        ProjectTreeProvider.closeProject();
+                        ProjectTreeProvider.instance().updateData(null);
                     }
                 });
-            } catch (err) {
-                let msg = localize("autolispext.project.commands.closefailed", "Failed to close project.");
-                showErrorMessage(msg, err);
             }
         }));
 

--- a/extension/src/project/projectTree.ts
+++ b/extension/src/project/projectTree.ts
@@ -129,20 +129,12 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<DisplayNode>
     }
 
     public refreshData(data?: DisplayNode) {
-        vscode.commands.executeCommand("setContext", "autolisp.hasProject", ProjectTreeProvider.hasProjectOpened());
         this.onChanged.fire(data);
     }
 
     public get projectNode(): ProjectNode {
         return this.rootNode;
     }
-
-    public static closeProject(): void {
-        ProjectTreeProvider.currentInstance.rootNode = null;
-        ProjectTreeProvider.currentInstance.onChanged.fire(null);
-        vscode.commands.executeCommand("setContext", "autolisp.hasProject", false);
-    }
-
 
     public static hasProjectOpened(): Boolean {
         if (!ProjectTreeProvider.currentInstance)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,15 @@
 				}
 			},
 			{
+				"command": "autolisp.closeProject",
+				"category": "AutoLISP",
+				"title": "%autolispext.project.closeproject.title%",
+				"icon": {
+					"dark": "images/dark/close.svg",
+					"light": "images/light/close.svg"
+				}
+			},
+			{
 				"command": "autolisp.addFile2Project",
 				"category": "AutoLISP",
 				"title": "%autolispext.project.addfile.title%",
@@ -500,12 +509,17 @@
 				{
 					"command": "autolisp.addFile2Project",
 					"group": "navigation@3",
-					"when": "view == Autolisp-ProjectView"
+					"when": "view == Autolisp-ProjectView && autolisp.hasProject"
 				},
 				{
 					"command": "autolisp.refresh",
 					"group": "navigation@6",
-					"when": "view == Autolisp-ProjectView"
+					"when": "view == Autolisp-ProjectView && autolisp.hasProject"
+				},
+				{
+					"command": "autolisp.closeProject",
+					"group": "navigation@7",
+					"when": "view == Autolisp-ProjectView && autolisp.hasProject"
 				},
 				{
 					"command": "autolisp.findInProject",
@@ -548,6 +562,11 @@
 					"when": "view == Autolisp-ProjectView && viewItem == project",	
 					"command": "autolisp.SaveAll",	
 					"group": "navigation@4"	
+				},
+				{	
+					"when": "view == Autolisp-ProjectView && viewItem == project",	
+					"command": "autolisp.closeProject",	
+					"group": "navigation@5"	
 				},
 				{
 					"when": "view == Autolisp-ProjectView && viewItem == lspFile",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
 	"autolispext.debug.launchconfig.desc": "user settings for AutoCAD path and startup parameters.",
 	"autolispext.project.createproject.title": "Create a New Project",
 	"autolispext.project.openproject.title": "Open an Existing Project",
+	"autolispext.project.closeproject.title": "Close Project",
 	"autolispext.project.addfile.title": "Add File to Project",
 	"autolispext.project.removefile.title": "Remove File from Project",
 	"autolispext.project.saveproject.title": "Save Project",


### PR DESCRIPTION
**Objective/Abstraction**
The primary goal was to add ReadonlyDocument references to the PRJ LispFileNode's for the upcoming document management system. I expanded this to a Project Treeview feature update that allows users to close open projects. I did this because the future definitionProvider is intended to search PRJ's and open documents first when applicable. If it can't find what it was looking for there, then it will search the entire workspace. This new behavior means that both opening and closing a PRJ's to set a different baseline context can be a valuable behavioral tool for the users. A good example of this would be if (many do) users have "archive" folders and they don't want false positives from them, then they can simply dump all their core LSP's into a PRJ. If they are wanting to drudge through their history, they can easily do that too by closing the active PRJ.

**Implementation**
Added a close command to the PRJ Treeview's context menu and button bar. You'll notice that the icons on the Treeview button bar now support dynamic visibility contextual to the presence of a PRJ. Everything user-facing should have been localized. PRJ's now automatically create their ReadonlyDocument reference to be used for searching. The upcoming document manager will have a _get projectDocuments()_ that finds/returns a vscode.TextDocument[] from those LspFileNode's if available.

**Tests Passed/Screenshots**
![PR 29 PRJ UpdatesSmall](https://user-images.githubusercontent.com/51800232/95975388-f337b000-0dca-11eb-99c9-d727e33b0869.gif)