### PR TITLE
Rollout of AutoLispExt.localize() & General import header maintenance

### DIFF
--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -1,9 +1,8 @@
 import * as vscode from "vscode";
-import * as nls from 'vscode-nls';
+import { AutoLispExt } from './extension';
 import { openWebHelp } from './help/openWebHelp';
 import { showErrorMessage } from './project/projectCommands';
 
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerCommands(context: vscode.ExtensionContext){
 
@@ -14,7 +13,7 @@ export function registerCommands(context: vscode.ExtensionContext){
 		}
 		catch (err) {
 			if (err){
-				let msg = localize("autolispext.help.commands.openWebHelp", "Failed to load the webHelpAbstraction.json file");
+				let msg = AutoLispExt.localize("autolispext.help.commands.openWebHelp", "Failed to load the webHelpAbstraction.json file");
 				showErrorMessage(msg, err);
 			}
 		}
@@ -30,7 +29,7 @@ export function registerCommands(context: vscode.ExtensionContext){
 		}
 		catch (err) {
 			if (err){
-				let msg = localize("autolispext.commands.addFoldingRegion", "Failed to insert snippet");
+				let msg = AutoLispExt.localize("autolispext.commands.addFoldingRegion", "Failed to insert snippet");
 				showErrorMessage(msg, err);
 			}
 		}

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -11,16 +11,30 @@ export class ContextManager{
 	
 	localize = nls.config({ messageFormat: nls.MessageFormat.file })();	
 	
-	get Context(): vscode.ExtensionContext { return this._ctx; }
-	get Documents(): DocumentManager { return this._docManager; }
-	get Selectors(): typeof DocumentManager.Selectors { return DocumentManager.Selectors; }
-	get AllSelectors(): string[] { return [DocumentManager.Selectors.lsp, DocumentManager.Selectors.dcl, DocumentManager.Selectors.prj]; }
-	get Subscriptions(): Disposable[] { return this._ctx ? this._ctx.subscriptions : null; }
-	get ExtPath(): string { return this._ctx ? this._ctx.extensionPath : ""; }
-	get Data() { return Resources; }
+	get Context(): vscode.ExtensionContext { 
+		return this._ctx; 
+	}
+	get Documents(): DocumentManager { 
+		return this._docManager; 
+	}
+	get Selectors(): typeof DocumentManager.Selectors { 
+		return DocumentManager.Selectors; 
+	}
+	get AllSelectors(): string[] { 
+		return [DocumentManager.Selectors.lsp, DocumentManager.Selectors.dcl, DocumentManager.Selectors.prj]; 
+	}
+	get Subscriptions(): Disposable[] { 
+		return this._ctx ? this._ctx.subscriptions : null; 
+	}
+	get ExtPath(): string { 
+		return this._ctx ? this._ctx.extensionPath : ""; 
+	}
+	get Data() { 
+		return Resources; 
+	}
 
 	
-	initialize(context: vscode.ExtensionContext) {
+	initialize(context: vscode.ExtensionContext): void {
 		this._ctx = context;
 		this._docManager = new DocumentManager();
 	}

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -4,13 +4,13 @@ import * as Resources from "./resources";
 import { Disposable } from 'vscode-languageclient';
 import { DocumentManager } from './documents';
 
-
+// This is a singleton class
 export class ContextManager{
 	private _ctx: vscode.ExtensionContext;
 	private _docManager: DocumentManager;
 	
-	localize = nls.config({ messageFormat: nls.MessageFormat.file })();	
-	
+	localize: nls.LocalizeFunc = nls.config({ messageFormat: nls.MessageFormat.file })();
+
 	get Context(): vscode.ExtensionContext { 
 		return this._ctx; 
 	}

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -1,0 +1,27 @@
+import * as vscode from "vscode";
+import * as nls from "vscode-nls";
+import * as Resources from "./resources";
+import { Disposable } from 'vscode-languageclient';
+import { DocumentManager } from './documents';
+
+
+export class ContextManager{
+	private _ctx: vscode.ExtensionContext;
+	private _docManager: DocumentManager;
+	
+	localize = nls.config({ messageFormat: nls.MessageFormat.file })();	
+	
+	get Context(): vscode.ExtensionContext { return this._ctx; }
+	get Documents(): DocumentManager { return this._docManager; }
+	get Selectors(): typeof DocumentManager.Selectors { return DocumentManager.Selectors; }
+	get AllSelectors(): string[] { return [DocumentManager.Selectors.lsp, DocumentManager.Selectors.dcl, DocumentManager.Selectors.prj]; }
+	get Subscriptions(): Disposable[] { return this._ctx ? this._ctx.subscriptions : null; }
+	get ExtPath(): string { return this._ctx ? this._ctx.extensionPath : ""; }
+	get Data() { return Resources; }
+
+	
+	initialize(context: vscode.ExtensionContext) {
+		this._ctx = context;
+		this._docManager = new DocumentManager();
+	}
+}

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import * as Net from 'net';
 import * as os from 'os';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from './extension';
 
 import { pickProcess } from './process/acadPicker';
 import { calculateABSPathForDAP } from './platform';
@@ -11,8 +9,8 @@ import { existsSync } from 'fs';
 import { ProcessPathCache } from './process/processCache';
 import { DiagnosticsCtrl } from './diagnosticsCtrl';
 
-let strNoADPerr: string = localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
-let strNoACADerr: string = localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
+let strNoADPerr: string = AutoLispExt.localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
+let strNoACADerr: string = AutoLispExt.localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
 let acadPid2Attach = -1;
 
 let attachCfgName = 'AutoLISP Debug: Attach';
@@ -89,7 +87,7 @@ export function registerLispDebugProviders(context: vscode.ExtensionContext) {
                 setDefaultAcadPid(-1);
             }
             else if (event.event === "acadnosupport") {
-                let msg = localize("autolispext.debug.acad.nosupport",
+                let msg = AutoLispExt.localize("autolispext.debug.acad.nosupport",
                     "This instance of AutoCAD doesn’t support debugging AutoLISP files, use a release later than AutoCAD 2020.");
                 vscode.window.showErrorMessage(msg);
             }
@@ -141,24 +139,24 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
             }
 
             if (!productPath) {
-                let info = localize("autolispext.debug.launchjson.path",
+                let info = AutoLispExt.localize("autolispext.debug.launchjson.path",
                     "Specify the absolute path to the product with the Path attribute of the launch.json file.");
                 vscode.window.showInformationMessage(info);
                 let platform = os.type();
                 if (platform === 'Windows_NT') {
-                    let msg = localize("autolispext.debug.prod.path.win",
+                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.win",
                         "Specify the absolute path for the product. For example, C://Program Files//Autodesk//AutoCAD//acad.exe.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
                 else if (platform === 'Darwin') {
-                    let msg = localize("autolispext.debug.prod.path.osx",
+                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.osx",
                         "Specify the absolute path for the product. For example, /Applications/Autodesk/AutoCAD.app/Contents/MacOS/AutoCAD.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
                 else {
-                    let msg = localize("autolispext.debug.prod.path.other", "Specify the absolute path for the product.");
+                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.other", "Specify the absolute path for the product.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
@@ -234,7 +232,7 @@ class LispAttachConfigurationProvider implements vscode.DebugConfigurationProvid
         ProcessPathCache.clearProductProcessPathArr();
         let processId = await pickProcess(false, acadPid2Attach);
         if (!processId) {
-            let msg = localize("autolispext.debug.noprocess.eror", "No process for which to attach could be found.");
+            let msg = AutoLispExt.localize("autolispext.debug.noprocess.eror", "No process for which to attach could be found.");
             return vscode.window.showInformationMessage(msg).then(_ => {
                 return undefined;	// abort attach
             });

--- a/extension/src/documents.ts
+++ b/extension/src/documents.ts
@@ -1,0 +1,273 @@
+
+import * as vscode from 'vscode';
+import { ReadonlyDocument } from "./project/readOnlyDocument";
+import { AutoLispExt } from './extension';
+import { ProjectTreeProvider  } from "./project/projectTree";
+
+
+export class DocumentManager{	
+	private _opened: Map<string, vscode.TextDocument> = new Map();
+	private _workspace: Map<string, ReadonlyDocument> = new Map();
+	private _watchers: vscode.FileSystemWatcher[] = [];
+	
+	get OpenedDocuments(): ReadonlyDocument[] { return this.getOpenedAsReadonlyDocuments(); }
+	get WorkspaceDocuments(): ReadonlyDocument[] { return this.getWorkspaceDocuments(); }
+	get ProjectDocuments(): ReadonlyDocument[] { return this.getProjectDocuments(); }
+	get ActiveDocument(): ReadonlyDocument { return vscode.window.activeTextEditor ? ReadonlyDocument.getMemoryDocument(vscode.window.activeTextEditor.document) : undefined; }
+	
+	get ActiveTextDocument(): vscode.TextDocument { return vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document :  null; }
+	get OpenedTextDocuments(): vscode.TextDocument[] { return [...this._opened.values()]; }
+	
+
+	// General purpose methods for identifying the scope of work for a given document type
+	getSelectorType(fspath: string): string { return DocumentManager.getSelectorType(fspath); }
+	public static getSelectorType(fspath: string): string {
+		const ext: string = fspath.toUpperCase().slice(-4);
+		switch (ext) {
+			case ".LSP": return DocumentManager.Selectors.lsp;
+			case ".MNL": return DocumentManager.Selectors.lsp;
+			case ".PRJ": return DocumentManager.Selectors.prj;
+			case ".DCL": return DocumentManager.Selectors.dcl;
+			default: return "";
+		}
+	}
+
+	// Gets an array of PRJ ReadonlyDocument references, but prefers vscode.TextDocument's as their source when available
+	private getProjectDocuments(): ReadonlyDocument[] {
+		if (ProjectTreeProvider.hasProjectOpened()) {
+			return ProjectTreeProvider.instance().projectNode.sourceFiles.map(x => 
+				this._opened.has(x.document.fileName) ? ReadonlyDocument.getMemoryDocument(this._opened.get(x.document.fileName)) : x.document
+				);
+		} else {
+			return [];
+		}
+	}
+
+	// Gets an array of ReadonlyDocument references representing the _opened Map, but uses the native vscode.TextDocument's as their data source to provide more accurate information
+	private getOpenedAsReadonlyDocuments(): ReadonlyDocument[] {
+		const result: ReadonlyDocument[] = [];
+		this._opened.forEach(doc => {
+			result.push(ReadonlyDocument.getMemoryDocument(doc));
+		});
+		return result;
+	}
+
+	// Gets a complete (data populated) set of ReadonlyDocuments representing the workspace, but it will prefer vscode.TextDocument data sources from the _opened Map when available
+	private getWorkspaceDocuments(): ReadonlyDocument[] {
+		const result: ReadonlyDocument[] = [];
+		[...this._workspace.keys()].forEach(key => {
+			if (this._opened.has(key)){
+				result.push(ReadonlyDocument.getMemoryDocument(this._opened.get(key)));
+			} else if (this._workspace.get(key) === null) {
+				this._workspace.set(key, ReadonlyDocument.open(key));
+				result.push(this._workspace.get(key) as ReadonlyDocument);
+			} else {
+				result.push(this._workspace.get(key));
+			}
+		});
+		return result;
+	}
+
+	private initialize(){
+		this._opened.clear();
+		this._workspace.clear();
+		this._watchers.forEach(w => {
+			w.dispose();
+		});
+		this._watchers.length = 0;
+
+		// Grab the opened document (if available) and add it as our first known opened document
+		//		It is important to start tracking this early because we can't actually see what is opened by VSCode during its internal workspace reload.
+		//		Our first opportunity to capture these previously opened documents is when they are activated. **Unavoidable Technical Debt that needs future resolution**
+		if (vscode.window.activeTextEditor && this.getSelectorType(vscode.window.activeTextEditor.document.fileName) === DocumentManager.Selectors.lsp) {
+			this._opened.set(vscode.window.activeTextEditor.document.uri.fsPath, vscode.window.activeTextEditor.document);
+		}
+
+		// This builds the '_workspace' *.LSP Memory Document placeholder set
+		// 		This feature does make the "fair assumption" that AutoCAD machines has plenty of memory to be holding all this information
+		// 		This was stress tested with a root workspace folder containing 10mb of *.LSP files and the memory footprint increased less than 50mb
+		vscode.workspace.findFiles("**").then((items: vscode.Uri[]) => {
+			items.forEach((fileUri: vscode.Uri) => {			
+				if (this.getSelectorType(fileUri.fsPath) === DocumentManager.Selectors.lsp) {
+					this._workspace.set(fileUri.fsPath, null); // initialized as null to blueprint the workspace files without the overhead of reading their contents
+				}
+			});
+		});
+		
+		if (vscode.workspace.workspaceFolders) {
+			this.setupFileSystemWatchers();
+		}
+	}
+
+	private setupFileSystemWatchers(){
+		vscode.workspace.workspaceFolders.forEach(folder => {
+			const pattern = new vscode.RelativePattern(folder, "**");
+			const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false);
+
+			AutoLispExt.Subscriptions.push(watcher.onDidDelete((e: vscode.Uri) => {		
+				if (this._workspace.has(e.fsPath) === true) {
+					this._workspace.delete(e.fsPath);
+				}		
+			}));
+		
+	
+			AutoLispExt.Subscriptions.push(watcher.onDidCreate((e: vscode.Uri) => {
+				if (this.getSelectorType(e.fsPath) === DocumentManager.Selectors.lsp) {
+					if (this._workspace.has(e.fsPath) === false) {
+						this._workspace.set(e.fsPath, null);
+					}
+				}
+			}));
+	
+			AutoLispExt.Subscriptions.push(watcher.onDidChange((e: vscode.Uri) => {
+				if (this._workspace.has(e.fsPath) === false) {
+					this._workspace.set(e.fsPath, null);
+				}
+			}));
+
+			this._watchers.push(watcher);
+		});
+	}
+
+	constructor() {
+		// **Event General Concepts**
+		//		vscode.workspace.onDid() events are only concerned with maintaining the _opened Map
+		//		FileSystemWatcher.onDid() events are only concerned with maintaining the _workspace Map
+		//		The FSW Create/Change events arbitrarily add the fspath to the _workspace Map set to null. The insures that any underlying data changes will get reloaded at the next get() query.
+		//		The ultimate goal of the _workspace Map is only to keep a complete set of fspath pointers to LSP files within the workspace.
+		//			These pointers may not actually contain document content. If they've been queried since the last time they initialized or changed, then they have data, else they are null
+		//			If they are null, then requesting the data will synchronously load/serve the contents as if it were there to begin with; this is expected to cause a single lag at the first occurrence
+		//			As long as the FileSystemWatcher.OnDidChange doesn't fire on that fspath again, then they will persist data to be used for making GoTo & AutoCompletion extremely responsive
+		
+		// **Unused vscode.workspace.onDid() Event Documentation**
+		// 		onDidChangeConfiguration		Not Used and not tested
+		// 		onDidChangeTextDocument			Unnecessary because this can only relate to opened documents and we already cached the vscode.TextDocument reference during onDidOpenTextDocument
+		// 		onDidCreateFiles				These will get captured by the workspace.onDidOpenTextDocument event
+		// 		onDidRenameFiles				These are captured by the onDidOpenTextDocument/onDidCloseTextDocument and/or the FileSystemWatcher.onDidCreate/onDidDelete events
+		// 		onDidSaveTextDocument			Unnecessary because this can only relate to opened documents and we already cached the vscode.TextDocument reference during onDidOpenTextDocument
+		
+		// **Behavioral Documentation**
+		// Scenario 1: Opened (workspace or non-workspace) *.LSP document
+		// workspace.onDidOpenTextDocument
+		//		Collects the TextDocument reference and add it to the _opened Map
+
+		// Scenario 2: Close (workspace or non-workspace) *.LSP document
+		// workspace.onDidCloseTextDocument 
+		//		Remove the TextDocument from the _opened Map
+		// 		Removed _workspace maintenance from this operation to properly separate concerns. We could update the ReadonlyDocument, but that represents very minimal overhead to reload it
+		//			Any save operations by the UI would have already nulled the _workspace reference to cause a regeneration of its data.
+		// 			Should the document gets re-opened later we'll start using the TextDocument again anyway.
+
+		// Scenario 3: Create or Add file in workspace from OS File Manager
+		// FileSystemWatcher.OnDidCreate
+		//		If it is an LSP file, then add the fspath to the _workspace Map initialized to null
+
+		// Scenario 4: Create file from workspace UI
+		// workspace.onDidOpenTextDocument -> FileSystemWatcher.onDidCreate
+		//		If it was an LSP, then the onDidOpenTextDocument will add the vscode.TextDocument object to the _opened Map
+		//		The onDidCreate events only goal is to creates or updates the _workspace Map entry for this fspath initialized to null
+
+		// Scenario 5: Delete opened file from workspace UI
+		// workspace.onDidCloseTextDocument -> workspace.onDidDeleteFiles -> FileSystemWatcher.onDidDelete
+		// 		The onDidCloseTextDocument will handle removing the _opened reference
+		//		For some reason the first onDidDelete is a Uri to the root folder of the workspace. This is passively ignored by our system since it isn't a document.
+		//		The onDidDelete removes the OLD fspath from the _workspace Map
+
+		// Scenario 6: Delete closed file from workspace UI
+		// workspace.onDidDeleteFiles -> FileSystemWatcher.onDidDelete
+		//		For some reason the first onDidDelete is a Uri to the root folder of the workspace. This is passively ignored by our system since it isn't a document.
+		//		The onDidDeleteFiles event would verify the fspath doesn't exist in the _opened Map. 
+		//		The onDidDelete event would remove any *.LSP items from the _workspace Map
+
+		// Scenario 7: Delete opened file from OS File Manager
+		// FileSystemWatcher.onDidDelete
+		// 		The vscode.TextDocument reference would remain in the _opened until the user closes it. 
+		//			If they later save it, then it will re-enter the _workspace through the onDidCreate
+		//		The onDidDelete will go ahead and purge the reference from the _workspace as intended
+
+		// Scenario 8: Delete closed file from OS File Manager
+		// FileSystemWatcher.onDidDelete
+		//		The onDidDelete will go ahead and purge the reference from the _workspace as intended
+
+		// Scenario 9: Edit/Save workspace file from outside of VSCode
+		// FileSystemWatcher.onDidChange
+		//		The onDidChange will null the fspath in the _workspace Map. Which would later get dynamically populated with current data when queried.
+		//		If this file was opened, then VSCode would have reloaded its TextDocument representation for us anyway **VERIFIED**
+
+		// Scenario 10: Edit/Save an opened workspace file from inside VSCode
+		// FileSystemWatcher.onDidChange
+		//		We already have the internal TextDocument object stored in our _opened Map, so letting onDidChange null the fspath in the _workspace Map is fine.
+		//		Already having the TextDocument reference is why we aren't bothering to hook up an event triggers on workspace.onDidSaveTextDocument/workspace.onDidChangeTextDocument		
+
+		// Scenario 11: Renamed opened workspace file from workspace UI
+		// workspace.onDidOpenTextDocument -> workspace.onDidCloseTextDocument [-> workspace.onDidRenameFiles] -> FileSystemWatcher.onDidCreate -> FileSystemWatcher.onDidDelete
+		//		The onDidOpenTextDocument event will add the NEW TextDocument object to the _opened Map
+		//		The onDidCloseTextDocument event will delete the OLD TextDocument object from the _opened Map and erroneously update the _workspace ReadonlyDocument from the TextDocument
+		//		The workspace.onDidRenameFiles was removed because it was deemed to be unnecessary by the prior 2 event calls
+		//		The onDidCreate sets the NEW fspath to null in the _workspace Map
+		//		The onDidDelete removes the OLD fspath from the _workspace Map
+
+		// Scenario 12: Renamed closed workspace file from workspace UI - workspace.rename, fswCreate, fsw.Delete(2x the first is _workspace directory root for some reason)
+		// workspace.onDidRenameFiles -> FileSystemWatcher.onDidCreate -> FileSystemWatcher.onDidDelete -> FileSystemWatcher.onDidDelete
+		//		The onDidCreate sets the NEW fspath to null in the _workspace Map
+		//		For some reason the first onDidDelete is a Uri to the root folder of the workspace. This is passively ignored by our system since it isn't a document.
+		//		The onDidDelete removes the OLD fspath from the _workspace Map
+
+		// Scenario 13: Renamed closed workspace file from OS File Manager - fswCreate, fsw.Delete
+		// FileSystemWatcher.onDidCreate -> FileSystemWatcher.onDidDelete
+		//		The onDidCreate sets the NEW fspath to null in the _workspace Map
+		//		The onDidDelete removes the OLD fspath from the _workspace Map
+
+		// Scenario 14: SaveAs opened non-workspace file from VSCode
+		// workspace.onDidOpenTextDocument -> workspace.onDidCloseTextDocument 
+		//		The onDidOpenTextDocument event will add the NEW TextDocument object to the _opened Map
+		//		The onDidCloseTextDocument event will delete the OLD TextDocument object from the _opened Map
+		
+		// Create FileSystemWatcher's & build the workspace blueprint
+		this.initialize();
+
+		AutoLispExt.Subscriptions.push(vscode.workspace.onDidCloseTextDocument((e: vscode.TextDocument) => {
+			if (this._opened.has(e.uri.fsPath) === true) {
+				this._opened.delete(e.uri.fsPath);
+			}
+		}));
+	
+		AutoLispExt.Subscriptions.push(vscode.workspace.onDidOpenTextDocument((e: vscode.TextDocument) => {
+			if (this.getSelectorType(e.fileName) === DocumentManager.Selectors.lsp) {
+				this._opened.set(e.uri.fsPath, e);		
+			}
+		}));
+
+		AutoLispExt.Subscriptions.push(vscode.workspace.onDidDeleteFiles((e: vscode.FileDeleteEvent) => {
+			e.files.forEach(file => {
+				if (this._opened.has(file.fsPath)) {
+					this._opened.delete(file.fsPath);
+				}
+			});
+		}));
+
+		// This allows the system to hook back up in the desired way should the user add or remove a folder to the their workspace
+		// If a user entirely closes and/or directly opens a different folder as their workspace, then our extensions essentially starts a new as if never activated
+		AutoLispExt.Subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(async (e: vscode.WorkspaceFoldersChangeEvent) => {			
+			// backup the opened documents so their context can be persisted. These add/remove operations do not have the effect of closing open documents
+			const openedBackup = [...this._opened.values()]; 
+			// WorkspaceFoldersChangeEvent object tells us if it was added or removed, but it better to just reset all the events rather make seemingly futile attempts to pick/choose
+			this.initialize(); 
+			// restore the _opened documents Map
+			openedBackup.forEach(doc => { 
+				if (!this._opened.has(doc.fileName)) {
+					this._opened.set(doc.fileName, doc);
+				}
+			});
+		}));
+	} // End of DocumentManger Constructor
+}
+
+
+export namespace DocumentManager{
+	export enum Selectors {
+		lsp = "autolisp",
+		dcl = "autolispdcl",
+		prj = "autolispprj"
+	}
+}

--- a/extension/src/documents.ts
+++ b/extension/src/documents.ts
@@ -10,25 +10,43 @@ export class DocumentManager{
 	private _workspace: Map<string, ReadonlyDocument> = new Map();
 	private _watchers: vscode.FileSystemWatcher[] = [];
 	
-	get OpenedDocuments(): ReadonlyDocument[] { return this.getOpenedAsReadonlyDocuments(); }
-	get WorkspaceDocuments(): ReadonlyDocument[] { return this.getWorkspaceDocuments(); }
-	get ProjectDocuments(): ReadonlyDocument[] { return this.getProjectDocuments(); }
-	get ActiveDocument(): ReadonlyDocument { return vscode.window.activeTextEditor ? ReadonlyDocument.getMemoryDocument(vscode.window.activeTextEditor.document) : undefined; }
+	get OpenedDocuments(): ReadonlyDocument[] { 
+		return this.getOpenedAsReadonlyDocuments(); 
+	}
+	get WorkspaceDocuments(): ReadonlyDocument[] { 
+		return this.getWorkspaceDocuments(); 
+	}
+	get ProjectDocuments(): ReadonlyDocument[] { 
+		return this.getProjectDocuments(); 
+	}
+	get ActiveDocument(): ReadonlyDocument { 
+		return vscode.window.activeTextEditor ? ReadonlyDocument.getMemoryDocument(vscode.window.activeTextEditor.document) : undefined; 
+	}
 	
-	get ActiveTextDocument(): vscode.TextDocument { return vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document :  null; }
-	get OpenedTextDocuments(): vscode.TextDocument[] { return [...this._opened.values()]; }
+	get ActiveTextDocument(): vscode.TextDocument { 
+		return vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document :  null; 
+	}
+	get OpenedTextDocuments(): vscode.TextDocument[] { 
+		return [...this._opened.values()]; 
+	}
 	
 
 	// General purpose methods for identifying the scope of work for a given document type
-	getSelectorType(fspath: string): string { return DocumentManager.getSelectorType(fspath); }
+	getSelectorType(fspath: string): string { 
+		return DocumentManager.getSelectorType(fspath); 
+	}
 	public static getSelectorType(fspath: string): string {
-		const ext: string = fspath.toUpperCase().slice(-4);
-		switch (ext) {
-			case ".LSP": return DocumentManager.Selectors.lsp;
-			case ".MNL": return DocumentManager.Selectors.lsp;
-			case ".PRJ": return DocumentManager.Selectors.prj;
-			case ".DCL": return DocumentManager.Selectors.dcl;
-			default: return "";
+		if (fspath) {
+			const ext: string = fspath.toUpperCase().slice(-4);
+			switch (ext) {
+				case ".LSP": return DocumentManager.Selectors.lsp;
+				case ".MNL": return DocumentManager.Selectors.lsp;
+				case ".PRJ": return DocumentManager.Selectors.prj;
+				case ".DCL": return DocumentManager.Selectors.dcl;
+				default: return "";
+			}
+		} else {
+			return "";
 		}
 	}
 
@@ -68,7 +86,8 @@ export class DocumentManager{
 		return result;
 	}
 
-	private initialize(){
+	// Creates the FileSystemWatcher's & builds a workspace blueprint
+	private initialize(): void {
 		this._opened.clear();
 		this._workspace.clear();
 		this._watchers.forEach(w => {
@@ -99,7 +118,8 @@ export class DocumentManager{
 		}
 	}
 
-	private setupFileSystemWatchers(){
+	// integral to the initialize() function but separated for clarity
+	private setupFileSystemWatchers(): void {
 		vscode.workspace.workspaceFolders.forEach(folder => {
 			const pattern = new vscode.RelativePattern(folder, "**");
 			const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false);
@@ -251,7 +271,7 @@ export class DocumentManager{
 		AutoLispExt.Subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(async (e: vscode.WorkspaceFoldersChangeEvent) => {			
 			// backup the opened documents so their context can be persisted. These add/remove operations do not have the effect of closing open documents
 			const openedBackup = [...this._opened.values()]; 
-			// WorkspaceFoldersChangeEvent object tells us if it was added or removed, but it better to just reset all the events rather make seemingly futile attempts to pick/choose
+			// WorkspaceFoldersChangeEvent object tells us if it was added or removed, but it better to just reset all the events rather than make seemingly futile attempts to pick/choose
 			this.initialize(); 
 			// restore the _opened documents Map
 			openedBackup.forEach(doc => { 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,35 +1,28 @@
 
 'use strict';
 import * as vscode from 'vscode';
-
-import {
-	LanguageClient
-} from 'vscode-languageclient';
-
+import { LanguageClient } from 'vscode-languageclient';
+import { ContextManager } from "./context";
+// moved singleton AutoLispExt constructor ahead of 'our' other imports to create nls.localize() before they cause a null reference error
+export const AutoLispExt: ContextManager = new ContextManager();
 
 import * as Diagnostics from './diagnosticsCtrl';
 import { onUriRequested } from './uriHandler';
-
 import * as formatProviders from './format/formatProviders';
 import * as autoCompletionProvider from "./completion/autocompletionProvider";
 import * as statusBar from "./statusbar";
 import * as autoIndent from './format/autoIndent';
-import { ContextManager } from "./context";
 import * as DebugProviders from "./debug";
 import { registerProjectCommands } from "./project/projectCommands";
 import { registerCommands } from "./commands";
 import { loadAllResources } from "./resources";
-import * as nls from 'vscode-nls';
 
-// The example uses the file message format.
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-export const AutoLispExt: ContextManager = new ContextManager();
 let client: LanguageClient;
 
 loadAllResources();
 
 export function activate(context: vscode.ExtensionContext) {
-	AutoLispExt.initialize(context);	
+	AutoLispExt.initialize(context); 
 
 	//-----------------------------------------------------------
 	//1. lisp autoformat

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -14,7 +14,7 @@ import * as formatProviders from './format/formatProviders';
 import * as autoCompletionProvider from "./completion/autocompletionProvider";
 import * as statusBar from "./statusbar";
 import * as autoIndent from './format/autoIndent';
-
+import { ContextManager } from "./context";
 import * as DebugProviders from "./debug";
 import { registerProjectCommands } from "./project/projectCommands";
 import { registerCommands } from "./commands";
@@ -23,12 +23,13 @@ import * as nls from 'vscode-nls';
 
 // The example uses the file message format.
 const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-
+export const AutoLispExt: ContextManager = new ContextManager();
 let client: LanguageClient;
 
 loadAllResources();
 
 export function activate(context: vscode.ExtensionContext) {
+	AutoLispExt.initialize(context);	
 
 	//-----------------------------------------------------------
 	//1. lisp autoformat

--- a/extension/src/format/formatProviders.ts
+++ b/extension/src/format/formatProviders.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { LispFormatter } from './formatter'
-import * as utils from "../utils"
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { LispFormatter } from './formatter';
+import * as utils from "../utils";
+import { AutoLispExt } from '../extension';
+
 
 export function registerDocumentFormatter() {
     vscode.languages.registerDocumentFormattingEditProvider(['autolisp', 'lisp'], {
@@ -13,7 +13,7 @@ export function registerDocumentFormatter() {
             let currentLSPDoc = activeTextEditor.document.fileName;
             let ext = currentLSPDoc.substring(currentLSPDoc.length - 4, currentLSPDoc.length).toUpperCase();
             if (ext === ".DCL") {
-                let msg = localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
+                let msg = AutoLispExt.localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
                 vscode.window.showInformationMessage(msg);
                 return [];
             }
@@ -33,12 +33,12 @@ export function registeSelectionFormatter() {
             let currentLSPDoc = activeTextEditor.document.fileName;
             let ext = currentLSPDoc.substring(currentLSPDoc.length - 4, currentLSPDoc.length).toUpperCase();
             if (ext === ".DCL") {
-                let msg = localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
+                let msg = AutoLispExt.localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
                 vscode.window.showInformationMessage(msg);
                 return [];
             }
             if (activeTextEditor.selection.isEmpty) {
-                let msg = localize("autolispext.format.selectionlines", "First, select the lines of code to format.");
+                let msg = AutoLispExt.localize("autolispext.format.selectionlines", "First, select the lines of code to format.");
                 vscode.window.showInformationMessage(msg);
             }
 

--- a/extension/src/format/formatter.ts
+++ b/extension/src/format/formatter.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
-
 import { Sexpression } from "./sexpression";
 import { LispParser } from "./parser";
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
 
 export class LispFormatter {
 
@@ -60,7 +58,7 @@ export class LispFormatter {
 
                 let formatstr = lispLists.formatting(startColumn, linefeed);
                 if (formatstr.length == 0) {
-                    let msg = localize("autolispext.formatter.errors", "It meets some errors when formatting");
+                    let msg = AutoLispExt.localize("autolispext.formatter.errors", "It meets some errors when formatting");
                     throw new Error(msg);
                 }
 

--- a/extension/src/process/acadPicker.ts
+++ b/extension/src/process/acadPicker.ts
@@ -13,11 +13,8 @@ import { basename } from 'path';
 import { getProcesses } from './processTree';
 import {ProcessPathCache} from "./processCache";
 import { calculateACADProcessName } from '../platform';
-import { acitiveDocHasValidLanguageId } from '../utils';
-
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { activeDocHasValidLanguageId } from '../utils';
+import { AutoLispExt } from '../extension';
 interface ProcessItem extends vscode.QuickPickItem{
     pidOrPort:string;
     sortKey:number;
@@ -26,11 +23,11 @@ interface ProcessItem extends vscode.QuickPickItem{
 function getProcesspickerPlaceHolderStr(){
 	let platform = os.type();
 	if(platform === 'Windows_NT'){
-		return localize('autolispext.pickprocess.acad.win', "Pick the process to attach. Make sure AutoCAD, or one of the specialized toolsets, is running. Type acad and select it from the list.");
+		return AutoLispExt.localize('autolispext.pickprocess.acad.win', "Pick the process to attach. Make sure AutoCAD, or one of the specialized toolsets, is running. Type acad and select it from the list.");
 	}else if(platform === 'Darwin'){
-		return localize('autolispext.pickprocess.acad.osx', "Pick the process to attach. Make sure AutoCAD is running. Type AutoCAD and select it from the list.");
+		return AutoLispExt.localize('autolispext.pickprocess.acad.osx', "Pick the process to attach. Make sure AutoCAD is running. Type AutoCAD and select it from the list.");
 	}else{
-		return localize('autolispext.pickprocess.acad.other', "Pick the process to attach");
+		return AutoLispExt.localize('autolispext.pickprocess.acad.other', "Pick the process to attach");
 	}
 }
 
@@ -56,7 +53,7 @@ export function pickProcess(ports:any, defaultPid: number): Promise<string | nul
 		let choosedItem =  vscode.window.showQuickPick(items, options).then(item => item ? item.pidOrPort : null);
 		return choosedItem;
 	}).catch(err => {
-		let chooseItem = vscode.window.showErrorMessage(localize('autolispext.pickprocess.pickfailed', "Process picker failed ({0})", err.message), { modal: true }).then(_ => null);
+		let chooseItem = vscode.window.showErrorMessage(AutoLispExt.localize('autolispext.pickprocess.pickfailed', "Process picker failed ({0})", err.message), { modal: true }).then(_ => null);
 		return chooseItem;
 	});
 }
@@ -76,7 +73,7 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 		if(ProcessPathCache.globalAcadNameInUserAttachConfig){
 			processName = ProcessPathCache.globalAcadNameInUserAttachConfig;
 		}
-		else if (vscode.window.activeTextEditor && acitiveDocHasValidLanguageId()) {
+		else if (vscode.window.activeTextEditor && activeDocHasValidLanguageId()) {
 			//read attach configuration from launch.json
 			let configurations:[] = vscode.workspace.getConfiguration("launch", vscode.window.activeTextEditor.document.uri).get("configurations");
 			let attachLispConfig;
@@ -115,14 +112,14 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 
 		if (usePort) {
 			if (protocol === 'inspector') {
-				description = localize('autolispext.pickprocess.process.id.port', "process id: {0}, debug port: {1}", pid, port);
+				description = AutoLispExt.localize('autolispext.pickprocess.process.id.port', "process id: {0}, debug port: {1}", pid, port);
 			} else {
-				description = localize('autolispext.pickprocess.process.id.legacy', "process id: {0}, debug port: {1} (legacy protocol)", pid, port);
+				description = AutoLispExt.localize('autolispext.pickprocess.process.id.legacy', "process id: {0}, debug port: {1} (legacy protocol)", pid, port);
 			}
 			pidOrPort = `${protocol}${port}`;
 		} else {
 			if (protocol && port > 0) {
-				description = localize('autolispext.pickprocess.process.port.singal', "process id: {0}, debug port: {1} ({2})", pid, port, 'SIGUSR1');
+				description = AutoLispExt.localize('autolispext.pickprocess.process.port.singal', "process id: {0}, debug port: {1} ({2})", pid, port, 'SIGUSR1');
 				pidOrPort = `${pid}${protocol}${port}`;
 			} else {
 				// no port given
@@ -138,7 +135,7 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 
 				if(addintolist){
 					ProcessPathCache.addGlobalProductProcessPathArr(executablePath, pid);
-					description = localize('autolispext.pickprocess.process.id.singal', "process id: {0} ({1})", pid, 'SIGUSR1');
+					description = AutoLispExt.localize('autolispext.pickprocess.process.id.singal', "process id: {0} ({1})", pid, 'SIGUSR1');
 					pidOrPort = pid.toString();
 				}
 			}

--- a/extension/src/process/acadPicker.ts
+++ b/extension/src/process/acadPicker.ts
@@ -15,6 +15,7 @@ import {ProcessPathCache} from "./processCache";
 import { calculateACADProcessName } from '../platform';
 import { activeDocHasValidLanguageId } from '../utils';
 import { AutoLispExt } from '../extension';
+
 interface ProcessItem extends vscode.QuickPickItem{
     pidOrPort:string;
     sortKey:number;

--- a/extension/src/project/addFile2Project.ts
+++ b/extension/src/project/addFile2Project.ts
@@ -1,15 +1,12 @@
-import * as vscode from 'vscode'
+import * as vscode from 'vscode';
 import { ProjectTreeProvider, isFileAlreadyInProject, hasFileWithSameName } from './projectTree';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-
-import * as path from 'path'
+import { AutoLispExt } from '../extension';
+import * as path from 'path';
 
 export async function AddFile2Project() {
     try {
         if (ProjectTreeProvider.hasProjectOpened() == false) {
-            let msg = localize("autolispext.project.addfile.openproject", "A project must be open before you can add a file.");
+            let msg = AutoLispExt.localize("autolispext.project.addfile.openproject", "A project must be open before you can add a file.");
             return Promise.reject(msg);
         }
 
@@ -21,7 +18,7 @@ export async function AddFile2Project() {
         for (let file of selectedFiles) {
             let fileUpper = file.fsPath.toUpperCase();
             if (fileUpper.endsWith(".LSP") == false) {
-                let msg = localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
+                let msg = AutoLispExt.localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
                 return Promise.reject(msg);
             }
 
@@ -30,19 +27,19 @@ export async function AddFile2Project() {
                 //Legacy IDE doesn't allow user to add hello.lsp.lsp into a project, but if there happen to be a file
                 //  named hello.lsp, it will add hello.lsp into project, and this is wrong.
                 //To keep consistency with legacy IDE, we have to reject files of this kind.
-                let msg = localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
+                let msg = AutoLispExt.localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
                 return Promise.reject(msg);
             }
 
             if (isFileAlreadyInProject(file.fsPath, ProjectTreeProvider.instance().projectNode)) {
-                let msg = localize("autolispext.project.addfile.filealreadyexist", "File already exists in this project: ");
+                let msg = AutoLispExt.localize("autolispext.project.addfile.filealreadyexist", "File already exists in this project: ");
                 vscode.window.showInformationMessage(msg + file.fsPath);
 
                 continue;
             }
 
             if(hasFileWithSameName(file.fsPath, ProjectTreeProvider.instance().projectNode)) {
-                let msg = localize("autolispext.project.addfile.samenameexist", "File with the same name already exists in this project: ");
+                let msg = AutoLispExt.localize("autolispext.project.addfile.samenameexist", "File with the same name already exists in this project: ");
                 vscode.window.showInformationMessage(msg + path.basename(file.fsPath));
 
                 continue;
@@ -79,7 +76,7 @@ function hasMultipleExtensions(filePath:string):boolean {
 }
 
 async function SelectLspFiles() {
-    let label = localize("autolispext.project.addfile.openlabel", "Add to Project");
+    let label = AutoLispExt.localize("autolispext.project.addfile.openlabel", "Add to Project");
     const options: vscode.OpenDialogOptions = {
         //TBD: globalize
         canSelectMany: true,

--- a/extension/src/project/checkUnsavedChanges.ts
+++ b/extension/src/project/checkUnsavedChanges.ts
@@ -2,9 +2,7 @@ import { SaveProject } from './saveProject';
 import { ProjectTreeProvider } from './projectTree';
 import * as vscode from 'vscode';
 import { pathEqual } from '../utils';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
 
 //return false if no project is opened or there are no unsaved changes or user select "Save" or "Don't Save" the changes
 //return true if there are unsaved changes and user select "Cancel" or just close the dialog
@@ -28,9 +26,9 @@ export async function CheckUnsavedChanges(): Promise<boolean> {
     
     // prompt user if there are unsaved changes
     if (root.projectModified || unsavedFiles.length > 0) {
-        let msg = localize("autolispext.project.checkunsavedchanges.message", "Unsaved changes found with the project or the files in the project.\nDo you want to save the changes?");
-        let save = localize("autolispext.project.checkunsavedchanges.save", "Save");
-        let dontSave = localize("autolispext.project.checkunsavedchanges.dontsave", "Don't Save");
+        let msg = AutoLispExt.localize("autolispext.project.checkunsavedchanges.message", "Unsaved changes found with the project or the files in the project.\nDo you want to save the changes?");
+        let save = AutoLispExt.localize("autolispext.project.checkunsavedchanges.save", "Save");
+        let dontSave = AutoLispExt.localize("autolispext.project.checkunsavedchanges.dontsave", "Don't Save");
         const selection = await vscode.window.showWarningMessage(msg, {modal: true}, save, dontSave);
         if (!selection) {
             return true;

--- a/extension/src/project/createProject.ts
+++ b/extension/src/project/createProject.ts
@@ -1,16 +1,13 @@
 
-import * as vscode from 'vscode'
+import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
-import * as path from 'path'
-
+import * as path from 'path';
 import { ProjectNode, LspFileNode } from './projectTree';
 import { ProjectDefinition } from './projectDefinition';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
 
 export async function getNewProjectFilePath() {
-    let label = localize("autolispext.project.createproject.createlabel", "Create");
+    let label = AutoLispExt.localize("autolispext.project.createproject.createlabel", "Create");
     const options: vscode.SaveDialogOptions = {
         //TBD: globalize
         saveLabel: label,
@@ -29,7 +26,7 @@ export async function getNewProjectFilePath() {
 export async function createProject(prjFilePath: string) {
     let prjPathUpper = prjFilePath.toUpperCase();
     if (prjPathUpper.endsWith(".PRJ") == false) {
-        let msg = localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
+        let msg = AutoLispExt.localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
         return Promise.reject(msg)
     }
 

--- a/extension/src/project/excludeFile.ts
+++ b/extension/src/project/excludeFile.ts
@@ -1,12 +1,10 @@
 import { LspFileNode, ProjectTreeProvider } from './projectTree';
 import { pathEqual } from '../utils';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
 
 export async function excludeFromProject(selected: LspFileNode) {
     if (ProjectTreeProvider.hasProjectOpened() == false) {
-        let msg = localize("autolispext.project.excludefile.openproject", "A project must be open before you can exclude a file.");
+        let msg = AutoLispExt.localize("autolispext.project.excludefile.openproject", "A project must be open before you can exclude a file.");
         return Promise.reject(msg);
     }
 
@@ -23,7 +21,7 @@ export async function excludeFromProject(selected: LspFileNode) {
     }
 
     if (index2Del < 0) {
-        let msg = localize("autolispext.project.excludefile.filenotexist", "File to exclude doesn't exist in the current project.");
+        let msg = AutoLispExt.localize("autolispext.project.excludefile.filenotexist", "File to exclude doesn't exist in the current project.");
         return Promise.reject(msg);
     }
 

--- a/extension/src/project/findReplace/applyReplacement.ts
+++ b/extension/src/project/findReplace/applyReplacement.ts
@@ -1,15 +1,13 @@
 import * as fs from 'fs-extra';
-import * as vscode from 'vscode'
-
+import * as vscode from 'vscode';
 import { FileNode } from './searchTree';
-import { getTmpFilePath, getDocument } from '../../utils';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { getDocument } from '../../utils';
+import { AutoLispExt } from '../../extension';
 
 export async function applyReplacementInFile(filePlan: FileNode) {
     try {
         if (fs.existsSync(filePlan.filePath) == false) {
-            filePlan.errorInReplace = localize("autolispext.project.findreplace.applyreplacement.filenotexist", "File doesn't exist.");
+            filePlan.errorInReplace = AutoLispExt.localize("autolispext.project.findreplace.applyreplacement.filenotexist", "File doesn't exist.");
             return;
         }
 
@@ -81,7 +79,7 @@ async function applyChangeInEditor(filePath: string, fileContent: string) {
 
         let succ = await vscode.workspace.applyEdit(edit);
         if (!succ) {
-            let msg = localize("autolispext.project.findreplace.applyreplacement.replacetextfailed", "Failed to replace text: ");
+            let msg = AutoLispExt.localize("autolispext.project.findreplace.applyreplacement.replacetextfailed", "Failed to replace text: ");
             throw new Error(msg + filePath);
         }
 

--- a/extension/src/project/findReplace/clearResults.ts
+++ b/extension/src/project/findReplace/clearResults.ts
@@ -1,9 +1,7 @@
 import { SearchTreeProvider, SummaryNode } from './searchTree';
 import { SearchOption } from './options';
-
-import * as vscode from 'vscode'
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import * as vscode from 'vscode';
+import { AutoLispExt } from '../../extension';
 
 export function clearSearchResults() {
     SearchTreeProvider.instance.clear();
@@ -31,7 +29,7 @@ let isSearching: boolean = false;
 //this method is expected to never throw error, as it will be the first method to call in many use cases
 export function getWarnIsSearching(): boolean {
     if (isSearching) {
-        let msg = localize("autolispext.project.findReplace.clearresults.issearching", "A search is in progress, wait until the current search has completed and try again.");
+        let msg = AutoLispExt.localize("autolispext.project.findReplace.clearresults.issearching", "A search is in progress, wait until the current search has completed and try again.");
         vscode.window.showInformationMessage(msg);
         return true;
     }

--- a/extension/src/project/findReplace/openSearchResult.ts
+++ b/extension/src/project/findReplace/openSearchResult.ts
@@ -4,8 +4,7 @@ import { getDocument } from '../../utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ReadonlyDocument } from '../readOnlyDocument';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../../extension';
 
 export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: SearchOption) {
 
@@ -18,7 +17,7 @@ export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: 
         const exists = fs.existsSync(finding.filePath);
 
         if (exists == false) {
-            let msg = localize("autolispext.project.findreplace.opensearchresult.filenotexist", "File doesn't exist: ");
+            let msg = AutoLispExt.localize("autolispext.project.findreplace.opensearchresult.filenotexist", "File doesn't exist: ");
             return Promise.reject(msg + finding.filePath);
         }
 
@@ -53,7 +52,7 @@ export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: 
         if (!doc) {
             doc = ReadonlyDocument.open(finding.filePath);
             if (!doc) {
-                let msg = localize("autolispext.project.findreplace.opensearchresult.openfailed", "File couldn't be opened: ");
+                let msg = AutoLispExt.localize("autolispext.project.findreplace.opensearchresult.openfailed", "File couldn't be opened: ");
                 return Promise.reject(msg + finding.filePath);
             }
         }

--- a/extension/src/project/findReplace/optionButton.ts
+++ b/extension/src/project/findReplace/optionButton.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import { IconUris } from '../icons';
 import { SearchOption } from './options';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../../extension';
 
 export class optionButton implements vscode.QuickInputButton {
     public constructor(iconUriOn: vscode.Uri, iconUriOff: vscode.Uri, isOn: boolean,
@@ -35,25 +34,25 @@ export class optionButton implements vscode.QuickInputButton {
 
     public static getButtons() {
         if (!optionButton.matchCaseBtn) {
-            let matchCase = localize("autolispext.project.findreplace.optionbutton.matchcase", "Match Case");
+            let matchCase = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.matchcase", "Match Case");
             optionButton.matchCaseBtn =
                 new optionButton(IconUris.matchCase(true), IconUris.matchCase(false), SearchOption.activeInstance.matchCase,
                     matchCase,
                     optionButton.name_MatchCase);
 
-            let matchWholeWord = localize("autolispext.project.findreplace.optionbutton.matchwholeword", "Match Whole Word");
+            let matchWholeWord = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.matchwholeword", "Match Whole Word");
             optionButton.matchWordBtn =
                 new optionButton(IconUris.matchWord(true), IconUris.matchWord(false), SearchOption.activeInstance.matchWholeWord,
                     matchWholeWord,
                     optionButton.name_MatchWord);
 
-            let regExp = localize("autolispext.project.findreplace.optionbutton.regexp", "Use Regular Expression");
+            let regExp = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.regexp", "Use Regular Expression");
             optionButton.useRegularExprBtn =
                 new optionButton(IconUris.useRegularExpr(true), IconUris.useRegularExpr(false), SearchOption.activeInstance.useRegularExpr,
                     regExp,
                     optionButton.name_UseRegularExpr);
 
-            let closeTooltip = localize("autolispext.project.findreplace.optionbutton.close", "Close");
+            let closeTooltip = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.close", "Close");
             optionButton.closeBtn = new optionButton(IconUris.closeUri(), null, true, closeTooltip, optionButton.name_Close);
         }
 

--- a/extension/src/project/findReplace/options.ts
+++ b/extension/src/project/findReplace/options.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 import { optionButton } from './optionButton';
 import { IconUris } from '../icons';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class SearchOption {
     static activeInstance: SearchOption = new SearchOption;//the one bound to search UI
@@ -110,7 +108,7 @@ export async function getString(title: string, hint: string) {
             quickpick.ignoreFocusOut = true;
 
             // TODO: do localization latter, now it has no enu\out\project\findReplace\options.i18n.json
-            //let closeTooltip = localize("autolispext.project.findreplace.optionbutton.close", "Close");
+            //let closeTooltip = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.close", "Close");
             let closeTooltip = "Close";
             let closeBtn = new optionButton(IconUris.closeUri(), null, true, closeTooltip, optionButton.name_Close);
             quickpick.buttons = [closeBtn];

--- a/extension/src/project/findReplace/replaceInProject.ts
+++ b/extension/src/project/findReplace/replaceInProject.ts
@@ -2,26 +2,24 @@ import { SearchTreeProvider } from './searchTree';
 import { FindInProject } from './findInProject';
 import { ProjectTreeProvider } from '../projectTree';
 import { getSearchOption, getString } from './options';
-
-import * as vscode from 'vscode'
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import * as vscode from 'vscode';
+import { AutoLispExt } from '../../extension';
 
 export async function replaceInProject() {
     if (ProjectTreeProvider.hasProjectOpened() == false) {
-        let msg = localize("autolispext.project.findreplace.replace.openproject", "A project must be open before you can replace a text string.");
+        let msg = AutoLispExt.localize("autolispext.project.findreplace.replace.openproject", "A project must be open before you can replace a text string.");
         vscode.window.showInformationMessage(msg);
         return;
     }
 
     //get find options: keyword, match case, etc.
-    let title = localize("autolispext.project.findreplace.replace.title", "Replace in Project");
-    let keywordHint = localize("autolispext.project.findreplace.replace.hint.keyword", "Type a text string to find, and press Enter.");
+    let title = AutoLispExt.localize("autolispext.project.findreplace.replace.title", "Replace in Project");
+    let keywordHint = AutoLispExt.localize("autolispext.project.findreplace.replace.hint.keyword", "Type a text string to find, and press Enter.");
     let opt = await getSearchOption(title, keywordHint);
     if (opt.isKeywordProvided() == false)
         return;
 
-    let replacementHint = localize("autolispext.project.findreplace.replace.hint.replacement", "Type a text string to replace with, and press Enter.");
+    let replacementHint = AutoLispExt.localize("autolispext.project.findreplace.replace.hint.replacement", "Type a text string to replace with, and press Enter.");
     //get the replacment of given keyword
     let repl = await getString(title, replacementHint);
     if (repl == undefined)

--- a/extension/src/project/findReplace/searchTree.ts
+++ b/extension/src/project/findReplace/searchTree.ts
@@ -1,10 +1,8 @@
 import { DisplayNode, ProjectNode } from '../projectTree';
 import { IconUris } from '../icons';
 import { SearchOption } from './options';
-
 import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../../extension';
 
 export class FileNode implements DisplayNode {
     filePath: string = '';
@@ -103,31 +101,31 @@ export class SummaryNode implements DisplayNode {
         let prjNameClause = '';
         let prjPathStatement = '';
         if (prjNode) {
-            let inStr = localize("autolispext.project.findreplace.searchtree.in", " in ");
-            let prjFileStr = localize("autolispext.project.findreplace.searchtree.prjfile", "\r\nProject file: ");
+            let inStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.in", " in ");
+            let prjFileStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.prjfile", "\r\nProject file: ");
             prjNameClause = inStr + `${prjNode.projectName}`;
             prjPathStatement = prjFileStr + `${prjNode.projectFilePath}`;
         }
 
         if (opt.isReplace) {
-            let replace = localize("autolispext.project.findreplace.searchtree.replace", "Replace ");
-            let withStr = localize("autolispext.project.findreplace.searchtree.with", " with ");
+            let replace = AutoLispExt.localize("autolispext.project.findreplace.searchtree.replace", "Replace ");
+            let withStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.with", " with ");
             this.tooltip = replace + `\"${opt.keyword}\"` + withStr + `\"${opt.replacement}\"${prjNameClause};`;
         }
         else {
-            let findStr = localize("autolispext.project.findreplace.searchtree.find", "Find ");
+            let findStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.find", "Find ");
             this.tooltip = findStr + `\"${opt.keyword}\"${prjNameClause};`;
         }
         this.tooltip += prjPathStatement;
 
         if (opt.matchCase) {
-            this.tooltip += localize("autolispext.project.findreplace.searchtree.matchcaseon", "\r\nMatch case: ON");
+            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.matchcaseon", "\r\nMatch case: ON");
         }
         if (opt.matchWholeWord) {
-            this.tooltip += localize("autolispext.project.findreplace.searchtree.matchwholewordon", "\r\nMatch whole word: ON");
+            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.matchwholewordon", "\r\nMatch whole word: ON");
         }
         if (opt.useRegularExpr) {
-            this.tooltip += localize("autolispext.project.findreplace.searchtree.regexpon", "\r\nUse regular expression: ON");
+            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.regexpon", "\r\nUse regular expression: ON");
         }
 
         this.tooltip += "\r\n" + this.summary;

--- a/extension/src/project/openLspFile.ts
+++ b/extension/src/project/openLspFile.ts
@@ -1,9 +1,7 @@
-import * as vscode from 'vscode'
-import { DisplayNode, LspFileNode, ProjectTreeProvider } from './projectTree'
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-const fs = require('fs')
+import * as vscode from 'vscode';
+import { DisplayNode, LspFileNode, ProjectTreeProvider } from './projectTree';
+import { AutoLispExt } from '../extension';
+import * as fs from 'fs';
 
 export async function openLspFile(clickedTreeItem: DisplayNode) {
 
@@ -19,7 +17,7 @@ export async function openLspFile(clickedTreeItem: DisplayNode) {
         }
 
         if (exists == false) {
-            let msg = localize("autolispext.project.openlspfile.filenotexist", "File doesn't exist: ");
+            let msg = AutoLispExt.localize("autolispext.project.openlspfile.filenotexist", "File doesn't exist: ");
             return Promise.reject(msg + lspNode.filePath);
         }
 

--- a/extension/src/project/openProject.ts
+++ b/extension/src/project/openProject.ts
@@ -1,16 +1,12 @@
-import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree'
+import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree';
 import { CursorPosition, ListReader } from '../format/listreader';
 import { Sexpression } from '../format/sexpression';
 import { ProjectDefinition } from './projectDefinition';
 import { CheckUnsavedChanges } from './checkUnsavedChanges';
-
-import * as vscode from 'vscode'
-import * as path from 'path'
+import * as vscode from 'vscode';
+import * as path from 'path';
 import { ReadonlyDocument } from './readOnlyDocument';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-const fs = require('fs');
+import { AutoLispExt } from '../extension';
 import * as os from 'os';
 
 export async function OpenProject() {
@@ -25,7 +21,7 @@ export async function OpenProject() {
 
         let prjPathUpper = prjUri.fsPath.toUpperCase();
         if (prjPathUpper.endsWith(".PRJ") == false) {
-            let msg = localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
+            let msg = AutoLispExt.localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
             return Promise.reject(msg);
         }
 
@@ -40,13 +36,13 @@ export async function OpenProject() {
 export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
     let document = ReadonlyDocument.open(prjUri.fsPath);
     if (!document) {
-        let msg = localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
+        let msg = AutoLispExt.localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
     let ret = ParseProjectDocument(prjUri.fsPath, document);
     if (!ret) {
-        let msg = localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
+        let msg = AutoLispExt.localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
@@ -54,7 +50,7 @@ export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
 }
 
 async function SelectProjectFile() {
-    let label = localize("autolispext.project.openproject.label", "Open Project");
+    let label = AutoLispExt.localize("autolispext.project.openproject.label", "Open Project");
     const options: vscode.OpenDialogOptions = {
         //TBD: globalize
         canSelectMany: false,

--- a/extension/src/project/projectCommands.ts
+++ b/extension/src/project/projectCommands.ts
@@ -14,10 +14,8 @@ import { replaceInProject } from './findReplace/replaceInProject';
 import { CheckUnsavedChanges } from './checkUnsavedChanges';
 import { clearSearchResults, clearSearchResultWithError, stopSearching, getWarnIsSearching } from './findReplace/clearResults';
 import { RefreshProject } from './refreshProject';
-
-import * as nls from 'vscode-nls';
+import { AutoLispExt } from '../extension';
 import { grantExePermission } from './findReplace/ripGrep';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerProjectCommands(context: vscode.ExtensionContext) {
     try {
@@ -42,7 +40,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(false);
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.createprojectfailed", "Failed to create the new project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.createprojectfailed", "Failed to create the new project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -59,16 +57,16 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                     ProjectTreeProvider.instance().updateData(prjNode);
                 })
                 .catch(err => {
-                    let msg = localize("autolispext.project.commands.openprojectfailed", "Failed to open the specified project.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.openprojectfailed", "Failed to open the specified project.");
                     showErrorMessage(msg, err);
                 });
         }));
 
         context.subscriptions.push(vscode.commands.registerCommand('autolisp.closeProject', async () => {
             if (ProjectTreeProvider.hasProjectOpened() === true){
-                let promptmsg = localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
-                let responseYes = localize("autolispext.project.commands.closepromptyes", "Yes");
-                let responseNo = localize("autolispext.project.commands.closepromptno", "No");
+                let promptmsg = AutoLispExt.localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
+                let responseYes = AutoLispExt.localize("autolispext.project.commands.closepromptyes", "Yes");
+                let responseNo = AutoLispExt.localize("autolispext.project.commands.closepromptno", "No");
                 vscode.window.showWarningMessage(promptmsg + ProjectTreeProvider.instance().projectNode.projectName, responseYes, responseNo).then(result => {
                     if (result === responseYes){
                         ProjectTreeProvider.instance().updateData(null);
@@ -87,7 +85,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                     return;//it's possible that the user cancelled the operation
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.addfilefailed", "Failed to add selected files to project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.addfilefailed", "Failed to add selected files to project.");
                 showErrorMessage(msg, err);
                 return;
             }
@@ -96,7 +94,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(true);
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -109,7 +107,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await excludeFromProject(selected);
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.removefilefailed", "Failed to remove selected file.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.removefilefailed", "Failed to remove selected file.");
                 showErrorMessage(msg, err);
                 return;
             }
@@ -118,7 +116,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(true);
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -129,11 +127,11 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
 
             SaveProject(true)
                 .then(prjPath => {
-                    let msg = localize("autolispext.project.commands.projectsaved", "Project file saved.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.projectsaved", "Project file saved.");
                     vscode.window.showInformationMessage(msg);
                 })
                 .catch(err => {
-                    let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                     showErrorMessage(msg, err);
                 });
         }));
@@ -144,11 +142,11 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
 
             SaveAll()
                 .then(() => {
-                    let msg = localize("autolispext.project.commands.allsaved", "All files saved.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.allsaved", "All files saved.");
                     vscode.window.showInformationMessage(msg);
                 })
                 .catch(err => {
-                    let msg = localize("autolispext.project.commands.saveallfailed", "Failed to save all the files in the project.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.saveallfailed", "Failed to save all the files in the project.");
                     showErrorMessage(msg, err);
                 });
         }));
@@ -157,7 +155,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
             try {
                 RefreshProject();
             } catch (err) {
-                let msg = localize("autolispext.project.commands.refreshfailed", "Failed to refresh the project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.refreshfailed", "Failed to refresh the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -165,7 +163,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.commands.registerCommand(ProjectTreeProvider.TreeItemClicked, (treeItem) => {
             openLspFile(treeItem)
                 .catch(err => {
-                    let msg = localize("autolispext.project.commands.openfilefailed", "Failed to open the file.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.openfilefailed", "Failed to open the file.");
                     showErrorMessage(msg, err);
                 })
         }));
@@ -176,7 +174,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 return;
 
             findInProject().catch(err => {
-                let msg = localize("autolispext.project.commands.findfailed", "Failed to find in project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.findfailed", "Failed to find in project.");
                 showErrorMessage(msg, err);
                 clearSearchResultWithError(msg + (err ? err.toString() : ''));
             });
@@ -188,7 +186,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 return;
 
             replaceInProject().catch(err => {
-                let msg = localize("autolispext.project.commands.replacefailed", "Failed to replace text string in project.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.replacefailed", "Failed to replace text string in project.");
                 showErrorMessage(msg, err);
                 clearSearchResultWithError(msg + (err ? err.toString() : ''));
             })
@@ -197,7 +195,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.commands.registerCommand(SearchTreeProvider.showResult, (treeItem) => {
             openSearchResult(treeItem, SearchTreeProvider.instance.lastSearchOption)
                 .catch(err => {
-                    let msg = localize("autolispext.project.commands.openresultfailed", "Failed to open search results.");
+                    let msg = AutoLispExt.localize("autolispext.project.commands.openresultfailed", "Failed to open search results.");
                     showErrorMessage(msg, err);
                 })
         }));
@@ -210,7 +208,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 clearSearchResults();
             }
             catch (err) {
-                let msg = localize("autolispext.project.commands.clearresultfailed", "Failed to clear search results.");
+                let msg = AutoLispExt.localize("autolispext.project.commands.clearresultfailed", "Failed to clear search results.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -230,7 +228,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         grantExePermission();
     }
     catch (e) {
-        let msg = localize("autolispext.project.commands.initializefailed", "Failed to initalize the AutoLISP Project Manager.");
+        let msg = AutoLispExt.localize("autolispext.project.commands.initializefailed", "Failed to initalize the AutoLISP Project Manager.");
         vscode.window.showErrorMessage(msg);
         console.log(e);
     }

--- a/extension/src/project/projectDefinition.ts
+++ b/extension/src/project/projectDefinition.ts
@@ -1,6 +1,4 @@
 import { Sexpression } from '../format/sexpression';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class ProjectDefinition {
     static key_name: string = ":NAME";

--- a/extension/src/project/projectTree.ts
+++ b/extension/src/project/projectTree.ts
@@ -4,10 +4,8 @@ import { ReadonlyDocument } from './readOnlyDocument';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { pathEqual } from '../utils';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-const fs = require('fs');
+import { AutoLispExt } from '../extension';
+import * as fs from 'fs';
 
 export interface DisplayNode {
     getDisplayText: () => string;
@@ -33,7 +31,7 @@ export class ProjectNode implements DisplayNode {
 
     getDisplayText(): string {
         if (this.projectModified) {
-            let unsaved = localize("autolispext.project.tree.unsaved", " (UNSAVED)");
+            let unsaved = AutoLispExt.localize("autolispext.project.tree.unsaved", " (UNSAVED)");
             return this.projectName + unsaved;
         } else {
             return this.projectName;
@@ -76,7 +74,7 @@ export class LspFileNode implements DisplayNode {
         if (this.fileExists) {
             return this.filePath;
         } else {
-            let msg = localize("autolispext.project.tree.filenotexist", "File doesn't exist: ");
+            let msg = AutoLispExt.localize("autolispext.project.tree.filenotexist", "File doesn't exist: ");
             return msg + this.filePath;
         }
     }

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -1,10 +1,9 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import * as nls from 'vscode-nls';
+import { AutoLispExt } from '../extension';
 import { LispParser } from '../format/parser';
 import { LispAtom, Sexpression } from '../format/sexpression';
 import { DocumentManager } from '../documents';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class ReadonlyLine implements vscode.TextLine {
     private constructor() {}
@@ -228,7 +227,7 @@ export class ReadonlyDocument implements vscode.TextDocument {
         }
 
         //the code shouldn't get here because it should have returned in the for loop when line == this.lineCount - 1
-        let msg = localize("autolispext.project.readonlydocument.convertoffsettopositionfailed", "Failed to convert offset to position.");
+        let msg = AutoLispExt.localize("autolispext.project.readonlydocument.convertoffsettopositionfailed", "Failed to convert offset to position.");
         throw new Error(msg);
     }
 

--- a/extension/src/project/saveProject.ts
+++ b/extension/src/project/saveProject.ts
@@ -1,22 +1,18 @@
 import { ProjectNode, ProjectTreeProvider } from './projectTree';
 import { ProjectDefinition } from './projectDefinition';
 import { LispFormatter } from '../format/formatter';
-
-import * as path from 'path'
+import * as path from 'path';
 import * as fs from 'fs-extra';
 import { pathEqual } from '../utils';
 import { ReadonlyDocument } from './readOnlyDocument';
-import * as nls from 'vscode-nls';
-
-import {longListFormatAsSingleColum, resetLongListFormatAsSingleColum} from '../format/sexpression'
-
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
+import {longListFormatAsSingleColum, resetLongListFormatAsSingleColum} from '../format/sexpression';
 import * as vscode from 'vscode';
 
 export async function SaveProject(refresh: boolean) {
     try {
         if (ProjectTreeProvider.hasProjectOpened() == false) {
-            let msg = localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
+            let msg = AutoLispExt.localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
             return Promise.reject(msg);
         }
 
@@ -25,7 +21,7 @@ export async function SaveProject(refresh: boolean) {
         //work out the correct project file text
         let prjFileText = generateProjectText(root);
         if (!prjFileText) {
-            let msg = localize("autolispext.project.saveproject.generateprjcontentfailed", "Failed to generate project content.");
+            let msg = AutoLispExt.localize("autolispext.project.saveproject.generateprjcontentfailed", "Failed to generate project content.");
             return Promise.reject(msg);
         }
 
@@ -59,7 +55,7 @@ export async function SaveProject(refresh: boolean) {
 export async function SaveAll() {
     const root = ProjectTreeProvider.instance().projectNode;
     if (!root) {
-        let msg = localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
+        let msg = AutoLispExt.localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
         return Promise.reject(msg);
     }
 

--- a/extension/src/resources.ts
+++ b/extension/src/resources.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { WebHelpLibrary } from "./help/openWebHelp";
+import * as fs from 'fs';
 
 
 export let internalLispFuncs: Array<string> = [];
@@ -29,7 +30,6 @@ export interface IJsonLoadable {
 
 
 function readJsonDataFile(datafile: string, intoObject: IJsonLoadable): void {
-	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {        
 		if (err === null && intoObject["loadFromJsonObject"]) {
@@ -40,7 +40,6 @@ function readJsonDataFile(datafile: string, intoObject: IJsonLoadable): void {
 
 
 function readDataFileByLine(datafile: string, action: (items: string[]) => void) {
-	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {
 		if (err === null) {
@@ -56,7 +55,6 @@ function readDataFileByLine(datafile: string, action: (items: string[]) => void)
 
 
 function readDataFileByDelimiter(datafile: string, delimiter: string, action: (item: string) => void) {
-	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {
 		var lineList = new Array<String>();

--- a/extension/src/statusbar.ts
+++ b/extension/src/statusbar.ts
@@ -1,15 +1,14 @@
 import * as vscode from 'vscode';
 import { isSupportedLispFile } from './platform';
 import * as os from 'os';
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from './extension';
 
 export function registerLoadLispButton(context: vscode.ExtensionContext) {
 	let lspLoadButton = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-	let title = localize("autolispext.loadlisp.title", "Load lisp");
+	let title = AutoLispExt.localize("autolispext.loadlisp.title", "Load lisp");
 	lspLoadButton.text = "📄" + title;
 	lspLoadButton.color = 'white';
-	lspLoadButton.tooltip = localize("autolispext.loadlisp.tooltip", "Load the Current File");
+	lspLoadButton.tooltip = AutoLispExt.localize("autolispext.loadlisp.tooltip", "Load the Current File");
 	lspLoadButton.command = "autolisp.loadActiveFile";
 	lspLoadButton.show();
 	context.subscriptions.push(vscode.commands.registerCommand("autolisp.loadActiveFile", () => {
@@ -19,17 +18,17 @@ export function registerLoadLispButton(context: vscode.ExtensionContext) {
 			if (vscode.debug.activeDebugSession !== undefined) {
 				vscode.debug.activeDebugSession.customRequest("customLoad", currentLSPDoc);
 			} else {
-				const message = localize("autolispext.loadlisp.attach", "First, attach to or launch a host application before loading this file.");
+				const message = AutoLispExt.localize("autolispext.loadlisp.attach", "First, attach to or launch a host application before loading this file.");
 				vscode.window.showErrorMessage(message);
 			}
 		} else {
 			let platform = os.type();
 			if(platform === 'Windows_NT'){
-				const message = localize("autolispext.loadlisp.fileformat.win", "This file format isn’t supported. Activate a window containing a DCL, LSP, or MNL file.");
+				const message = AutoLispExt.localize("autolispext.loadlisp.fileformat.win", "This file format isn’t supported. Activate a window containing a DCL, LSP, or MNL file.");
 				vscode.window.showErrorMessage(message);
 			}
 			else{
-				const message = localize("autolispext.loadlisp.fileformat.mac", "This file format isn’t supported. Activate a window containing a DCL or LSP file.");
+				const message = AutoLispExt.localize("autolispext.loadlisp.fileformat.mac", "This file format isn’t supported. Activate a window containing a DCL or LSP file.");
 				vscode.window.showErrorMessage(message);
 			}	
 		}

--- a/extension/src/uriHandler.ts
+++ b/extension/src/uriHandler.ts
@@ -2,13 +2,9 @@
 'use strict';
 
 import * as vscode from 'vscode';
-
-import {
-    acitiveDocHasValidLanguageId
-} from './utils'
-import { setDefaultAcadPid } from "./debug"
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { activeDocHasValidLanguageId } from './utils';
+import { setDefaultAcadPid } from "./debug";
+import { AutoLispExt } from './extension';
 
 function getUrlParams(queryString) {
     let hashes = queryString.split('&')
@@ -24,7 +20,7 @@ export function onUriRequested(uri: vscode.Uri) {
 
     let pidStr = qs["pid"];
     if (pidStr === undefined) {
-        let msg = localize("autolispext.urihandler.invaid", "Invalid call to AutoCAD AutoLISP Extension.");
+        let msg = AutoLispExt.localize("autolispext.urihandler.invaid", "Invalid call to AutoCAD AutoLISP Extension.");
         vscode.window.showInformationMessage(msg);
         return;
     }
@@ -32,20 +28,20 @@ export function onUriRequested(uri: vscode.Uri) {
     setDefaultAcadPid(parseInt(pidStr));
 
     if (vscode.debug.activeDebugSession) {
-        let msg = localize("autolispext.urihandler.activeddebugcfg", "Current debug configuration: ");
+        let msg = AutoLispExt.localize("autolispext.urihandler.activeddebugcfg", "Current debug configuration: ");
         vscode.window.showInformationMessage(msg + vscode.debug.activeDebugSession.name,
             modalMsgOption);
         return;
     }
 
     if (vscode.window.activeTextEditor) {
-        if (acitiveDocHasValidLanguageId()) {
-            let msg = localize("autolispext.urihandler.debug.start",
+        if (activeDocHasValidLanguageId()) {
+            let msg = AutoLispExt.localize("autolispext.urihandler.debug.start",
                 "From the menu bar, click Run > Start Debugging to debug the current AutoLISP source file.");
             vscode.window.showInformationMessage(msg, modalMsgOption);
         }
         else {
-            let msg = localize("autolispext.urihandler.debug.openfile",
+            let msg = AutoLispExt.localize("autolispext.urihandler.debug.openfile",
                 "Open an AutoLISP source file and click Run > Start Debugging from the menu bar to debug the file.");
             vscode.window.showInformationMessage(msg, modalMsgOption);
         }
@@ -53,7 +49,7 @@ export function onUriRequested(uri: vscode.Uri) {
         return;
     }
 
-    let msg = localize("autolispext.urihandler.debug.openfile",
+    let msg = AutoLispExt.localize("autolispext.urihandler.debug.openfile",
         "Open an AutoLISP source file and click Run > Start Debugging from the menu bar to debug the file.");
     vscode.window.showInformationMessage(msg, modalMsgOption);
 

--- a/extension/src/utils.ts
+++ b/extension/src/utils.ts
@@ -1,9 +1,8 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import * as path from 'path'
+import * as path from 'path';
 import * as fs from 'fs-extra';
-
-const os = require('os');
+import * as os from 'os';
 
 export function getFullDocRange(editor: vscode.TextEditor): vscode.Range {
     return editor.document.validateRange(
@@ -25,7 +24,7 @@ export function getSelectedDocRange(editor: vscode.TextEditor): vscode.Range {
     );
 }
 
-export function acitiveDocHasValidLanguageId(): Boolean {
+export function activeDocHasValidLanguageId(): Boolean {
     const editor = vscode.window.activeTextEditor;
 
     return editor.document.languageId === 'autolisp' ||

--- a/package.json
+++ b/package.json
@@ -602,6 +602,7 @@
 		"@types/mocha": "^5.2.7",
 		"@types/node": "8.10.18",
 		"@types/vscode": "^1.44.0",
+		"@types/fs-extra": "^8.1.0",
 		"del": "^4.1.1",
 		"event-stream": "^4.0.1",
 		"gulp": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,13 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@types/fs-extra@^8.1.0":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
+  integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"


### PR DESCRIPTION
**Objective**
Use a "common" instance of `nls.localize()` across the entire code base per the specifications of the official _vscode-nls_ project documentation.

**Abstraction/Implementation**
Import the AutoLispExt constant, remove all imports of vscode-nls and its config() variable. Update the remaining code to point to AutoLispExt.localize(). This did require some adjustment of the _extension.ts_ header to create the AutoLispExt singleton instance before our other /src/ imports tried referencing it. IE, the entire extension was failing to load before I did that; I added a comment to identify the criticality of its arrangement.

**Additional Context**
While I was doing this, I also did:
- performed some general maintenance on all the headers within files referencing vscode-nls to add semi-colons and replace `requires()` with `import` references
- fixed a function name in the utils.ts that misspelled 'active' so you will find the occasional instance where that name changed. 
- added a dev dependency to @types/fs-extra since some of our code was using it as a require() and converting it to an import caused complaints.

**Tests Performed**
I installed the Spanish language pack and the localization's I already know we have are working. However, I did notice that _F1 -> AutoLisp: Save Project_ without having one opened, did produced an error that was not localized. I don't believe we have one because nothing in the project appears to be configured to provide a localization of "_autolispext.project.saveproject.noprojecttosave_"

**Screenshots**
Not Applicable