### PR TITLE
Resolved Issue #36

### DIFF
--- a/extension/src/project/createProject.ts
+++ b/extension/src/project/createProject.ts
@@ -18,7 +18,7 @@ export async function getNewProjectFilePath() {
 
     let fileUri = await vscode.window.showSaveDialog(options);    
     if (fileUri) {
-        if (path.basename(fileUri.fsPath).split(' ').length === 1){
+        if (path.basename(fileUri.fsPath).indexOf(' ') >= 0) {
             return Promise.resolve(fileUri);
         } else {
             let msg = AutoLispExt.localize("autolispext.project.createproject.nospaces", "Legacy PRJ naming rules do not allow spaces");

--- a/extension/src/project/createProject.ts
+++ b/extension/src/project/createProject.ts
@@ -18,7 +18,7 @@ export async function getNewProjectFilePath() {
 
     let fileUri = await vscode.window.showSaveDialog(options);    
     if (fileUri) {
-        if (path.basename(fileUri.fsPath).indexOf(' ') >= 0) {
+        if (path.basename(fileUri.fsPath).indexOf(' ') === -1) {
             return Promise.resolve(fileUri);
         } else {
             let msg = AutoLispExt.localize("autolispext.project.createproject.nospaces", "Legacy PRJ naming rules do not allow spaces");

--- a/extension/src/project/createProject.ts
+++ b/extension/src/project/createProject.ts
@@ -1,16 +1,13 @@
 
-import * as vscode from 'vscode'
+import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
-import * as path from 'path'
-
+import * as path from 'path';
 import { ProjectNode, LspFileNode } from './projectTree';
 import { ProjectDefinition } from './projectDefinition';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+import { AutoLispExt } from '../extension';
 
 export async function getNewProjectFilePath() {
-    let label = localize("autolispext.project.createproject.createlabel", "Create");
+    let label = AutoLispExt.localize("autolispext.project.createproject.createlabel", "Create");
     const options: vscode.SaveDialogOptions = {
         //TBD: globalize
         saveLabel: label,
@@ -19,17 +16,23 @@ export async function getNewProjectFilePath() {
         }
     };
 
-    let fileUri = await vscode.window.showSaveDialog(options);
-    if (fileUri)
-        return Promise.resolve(fileUri);
-
-    return Promise.resolve(undefined);
+    let fileUri = await vscode.window.showSaveDialog(options);    
+    if (fileUri) {
+        if (path.basename(fileUri.fsPath).split(' ').length === 1){
+            return Promise.resolve(fileUri);
+        } else {
+            let msg = AutoLispExt.localize("autolispext.project.createproject.nospaces", "Legacy PRJ naming rules do not allow spaces");
+            return Promise.reject(msg);
+        }
+    } else {
+        return Promise.resolve(undefined);
+    }
 }
 
 export async function createProject(prjFilePath: string) {
     let prjPathUpper = prjFilePath.toUpperCase();
     if (prjPathUpper.endsWith(".PRJ") == false) {
-        let msg = localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
+        let msg = AutoLispExt.localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
         return Promise.reject(msg)
     }
 

--- a/extension/src/project/openProject.ts
+++ b/extension/src/project/openProject.ts
@@ -62,7 +62,7 @@ async function SelectProjectFile() {
 
     let fileUri = await vscode.window.showOpenDialog(options);
     if (fileUri && fileUri.length > 0){
-        if (path.basename(fileUri[0].fsPath).split(' ').length === 1){
+        if (path.basename(fileUri[0].fsPath).indexOf(' ') >= 0){
             return Promise.resolve(fileUri[0]);
         } else {
             let msg = AutoLispExt.localize("autolispext.project.openproject.nospaces", "Legacy PRJ naming rules do not allow spaces");

--- a/extension/src/project/openProject.ts
+++ b/extension/src/project/openProject.ts
@@ -1,16 +1,12 @@
-import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree'
+import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree';
 import { CursorPosition, ListReader } from '../format/listreader';
 import { Sexpression } from '../format/sexpression';
 import { ProjectDefinition } from './projectDefinition';
 import { CheckUnsavedChanges } from './checkUnsavedChanges';
-
-import * as vscode from 'vscode'
-import * as path from 'path'
+import * as vscode from 'vscode';
+import * as path from 'path';
 import { ReadonlyDocument } from './readOnlyDocument';
-
-import * as nls from 'vscode-nls';
-const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
-const fs = require('fs');
+import { AutoLispExt } from '../extension';
 import * as os from 'os';
 
 export async function OpenProject() {
@@ -25,7 +21,7 @@ export async function OpenProject() {
 
         let prjPathUpper = prjUri.fsPath.toUpperCase();
         if (prjPathUpper.endsWith(".PRJ") == false) {
-            let msg = localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
+            let msg = AutoLispExt.localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
             return Promise.reject(msg);
         }
 
@@ -40,13 +36,13 @@ export async function OpenProject() {
 export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
     let document = ReadonlyDocument.open(prjUri.fsPath);
     if (!document) {
-        let msg = localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
+        let msg = AutoLispExt.localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
     let ret = ParseProjectDocument(prjUri.fsPath, document);
     if (!ret) {
-        let msg = localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
+        let msg = AutoLispExt.localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
@@ -54,7 +50,7 @@ export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
 }
 
 async function SelectProjectFile() {
-    let label = localize("autolispext.project.openproject.label", "Open Project");
+    let label = AutoLispExt.localize("autolispext.project.openproject.label", "Open Project");
     const options: vscode.OpenDialogOptions = {
         //TBD: globalize
         canSelectMany: false,
@@ -65,10 +61,16 @@ async function SelectProjectFile() {
     };
 
     let fileUri = await vscode.window.showOpenDialog(options);
-    if (fileUri && fileUri.length > 0)
-        return Promise.resolve(fileUri[0]);
-
-    //return Promise.resolve(undefined) by default, and it means the operation is cancelled
+    if (fileUri && fileUri.length > 0){
+        if (path.basename(fileUri[0].fsPath).split(' ').length === 1){
+            return Promise.resolve(fileUri[0]);
+        } else {
+            let msg = AutoLispExt.localize("autolispext.project.openproject.nospaces", "Legacy PRJ naming rules do not allow spaces");
+            return Promise.reject(msg);
+        }
+    } else {
+        return Promise.resolve(undefined);
+    }
 }
 
 

--- a/extension/src/project/openProject.ts
+++ b/extension/src/project/openProject.ts
@@ -62,7 +62,7 @@ async function SelectProjectFile() {
 
     let fileUri = await vscode.window.showOpenDialog(options);
     if (fileUri && fileUri.length > 0){
-        if (path.basename(fileUri[0].fsPath).indexOf(' ') >= 0){
+        if (path.basename(fileUri[0].fsPath).indexOf(' ') === -1){
             return Promise.resolve(fileUri[0]);
         } else {
             let msg = AutoLispExt.localize("autolispext.project.openproject.nospaces", "Legacy PRJ naming rules do not allow spaces");


### PR DESCRIPTION
**Objective**
Aligned our PRJ filenames with the VLIDE legacy rules. Issue #36 illuminated that users could create PRJ files containing spaces and that did not match classic representations of PRJ names or their resulting internal structures.

**Abstraction/Implementation**
Added checks to see if the user provided path.basename() that contained spaces and threw a (localized) error to inform them of the issue.

**Additional Context**
Everything in these 2 files were manually aligned to PR #37 to avoid later merge conflicts. I'd probably still merge 37 before this one since we know this one adds on top of it.

**Tests Performed**
Created PRJ with and without spaces to see what succeeded/failed. Opened PRJ's with and without spaces to see what succeeded/failed.