### PR TITLE
Fix bug #44

### DIFF
--- a/extension/src/project/projectTree.ts
+++ b/extension/src/project/projectTree.ts
@@ -123,7 +123,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<DisplayNode>
     public updateData(newRootNode: ProjectNode) {
         this.rootNode = newRootNode;
         vscode.commands.executeCommand("setContext", "autolisp.hasProject", ProjectTreeProvider.hasProjectOpened());
-        this.onChanged.fire(this.rootNode);
+        this.refreshData(null);
     }
 
     public refreshData(data?: DisplayNode) {


### PR DESCRIPTION
The bug to fix:
https://github.com/Autodesk-AutoCAD/AutoLispExt/issues/44

When firing an event to refresh the entire project panel, it only works with a null argument.