### PR TITLE
Doc manager update

### DIFF
--- a/extension/src/documents.ts
+++ b/extension/src/documents.ts
@@ -153,7 +153,7 @@ export class DocumentManager{
 	// When the internal & native documents match in content the existing version is returned, but will be regenerated if they are not
 	private getOpenedAsReadonlyDocuments(): ReadonlyDocument[] {
 		const result: ReadonlyDocument[] = [];
-		[...this._cached.keys()].forEach(key => {
+		this.cacheKeys.forEach(key => {
 			const sources = this._cached.get(key);
 			if (sources.native && sources.flags.has(Origins.OPENED)){
 				if (!sources.internal || !sources.internal.equal(sources.native)){

--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -905,6 +905,9 @@ export class Sexpression extends LispAtom {
                 }
             });
         }
+        if (!result && this.contains(loc)){
+            result = this;
+        }
         return result;
     }
 

--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -905,9 +905,6 @@ export class Sexpression extends LispAtom {
                 }
             });
         }
-        if (!result && this.contains(loc)){
-            result = this;
-        }
         return result;
     }
 

--- a/extension/src/project/projectTree.ts
+++ b/extension/src/project/projectTree.ts
@@ -1,6 +1,5 @@
 import { IconUris } from './icons';
 import { ProjectDefinition } from './projectDefinition';
-import { ReadonlyDocument } from './readOnlyDocument';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { pathEqual } from '../utils';
@@ -62,7 +61,6 @@ export class ProjectNode implements DisplayNode {
 export class LspFileNode implements DisplayNode {
     filePath: string;
     fileExists: boolean;
-    document: ReadonlyDocument;
     rawFilePath: string;//the raw path string read from .prj file; for new added file, it should be null
 
     getDisplayText(): string {
@@ -235,7 +233,5 @@ export function addLispFileNode2ProjectTree(root: ProjectNode, fileName: string,
     fileNode.filePath = fileName;
     fileNode.fileExists = fs.existsSync(fileName);
     fileNode.rawFilePath = rawFilePath;
-    fileNode.document = ReadonlyDocument.open(fileName);
-    fileNode.document.updateAtomsForest();
     root.sourceFiles.push(fileNode);    
 }

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -266,6 +266,13 @@ export class ReadonlyDocument implements vscode.TextDocument {
     }
     //#endregion
 
+
+    equal(doc: vscode.TextDocument): boolean {
+        return this.fileName.toUpperCase().replace(/\//g, '\\') === doc.fileName.toUpperCase().replace(/\//g, '\\')
+               && this.fileContent === doc.getText();
+    }
+
+    
     // This is very similar to a DOM querySelector and is to be used for quickly finding all the Defun's or Setq's to determine available function/variable names.
     // The 'all' variable determines whether the function will continue digging inside a function it was able to match for nested versions.
     // Test Case: Temporarily added the following to extension.ts	

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -269,7 +269,7 @@ export class ReadonlyDocument implements vscode.TextDocument {
 
     equal(doc: vscode.TextDocument): boolean {
         return this.fileName.toUpperCase().replace(/\//g, '\\') === doc.fileName.toUpperCase().replace(/\//g, '\\')
-               && this.fileContent === doc.getText();
+               && this.fileContent === doc.getText().replace(/\r\n|\r|\n/g, '\r\n'); //.split('\r\n').join('\n').split('\n').join('\r\n');
     }
 
     

--- a/extension/src/providers/gotoProvider.ts
+++ b/extension/src/providers/gotoProvider.ts
@@ -55,7 +55,7 @@ export class AutolispDefinitionProvider implements vscode.DefinitionProvider{
 		let context = searchIn.getSexpressionFromPos(start);
 		let flag = true;
 		do {
-			const parent = searchIn.getParentOfSexpression(context);
+			const parent = !context ? searchIn : searchIn.getParentOfSexpression(context);			
 			const atom = parent?.getNthKeyAtom(0);
 			if (atom && SearchPatterns.LOCALIZES.test(atom.symbol)) {
 				let headers = parent.getNthKeyAtom(1);
@@ -77,32 +77,36 @@ export class AutolispDefinitionProvider implements vscode.DefinitionProvider{
 					result.push(new vscode.Location(vscode.Uri.file(doc.fileName), new vscode.Position(tmpVar.line, tmpVar.column)));
 				}
 			}
-			if (!parent || result.length > 0){
+			if (!parent || !context || result.length > 0 || parent.equal(context)) {
 				flag = false;
 			} else {
 				context = parent;
 			}
 		} while (flag);
 		// If we still haven't found anything check the 1st occurrence of setq's. This will find globals setqs and nested ones possibly inside other defuns
-		// if (result.length === 0){
-		// 	this.findInSetqs(doc, ucName).forEach(x => { result.push(x); });
-		// }
+		if (result.length === 0){
+			const possible = searchIn.findChildren(SearchPatterns.DEFINES, true).filter(p => p.contains(start));			
+			if (possible.length >= 0) {
+				this.findInSetqs(possible.pop(), ucName, doc.fileName).forEach(x => { result.push(x); });
+			}
+		}
 		return result;
 	}
 
-	private findInSetqs(doc: ReadonlyDocument, ucName: string): vscode.Location[] {
+	private findInSetqs(sexp: Sexpression, ucName: string, fileName: string): vscode.Location[] {
 		const result: vscode.Location[] = [];
-		doc.findExpressions(SearchPatterns.ASSIGNS).forEach(setq => {
+		const found = sexp.findChildren(SearchPatterns.ASSIGNS, false);
+		found.forEach(setq => {
 			let isVar = false;
-			let cIndex = setq.nextKeyIndex(0);
+			let cIndex = setq.nextKeyIndex(0, true);
 			do {
 				const atom = setq.atoms[cIndex];
 				if (isVar && atom?.symbol.toUpperCase() === ucName) {
-					result.push(new vscode.Location(vscode.Uri.file(doc.fileName), new vscode.Position(atom.line, atom.column)));
+					result.push(new vscode.Location(vscode.Uri.file(fileName), new vscode.Position(atom.line, atom.column)));
 				}
-				cIndex = setq.nextKeyIndex(cIndex);
+				cIndex = setq.nextKeyIndex(cIndex, true);
 				isVar = !isVar;
-			} while (cIndex && cIndex > -1);
+			} while (cIndex && cIndex > -1 && result.length === 0);
 		});
 		return result;
 	}

--- a/extension/src/providers/gotoProvider.ts
+++ b/extension/src/providers/gotoProvider.ts
@@ -8,7 +8,7 @@ import { SearchPatterns, SearchHandlers } from './providerShared';
 
 export class AutolispDefinitionProvider implements vscode.DefinitionProvider{
 	async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Location | vscode.Location[]> {
-		const rDoc = ReadonlyDocument.getMemoryDocument(document);
+		const rDoc = AutoLispExt.Documents.getDocument(document);
 		let selected = '';
 		rDoc.atomsForest.forEach(sexp => {
 			if (sexp instanceof Sexpression && sexp.contains(position)){

--- a/extension/src/providers/gotoProvider.ts
+++ b/extension/src/providers/gotoProvider.ts
@@ -84,9 +84,9 @@ export class AutolispDefinitionProvider implements vscode.DefinitionProvider{
 			}
 		} while (flag);
 		// If we still haven't found anything check the 1st occurrence of setq's. This will find globals setqs and nested ones possibly inside other defuns
-		if (result.length === 0){
-			this.findInSetqs(doc, ucName).forEach(x => { result.push(x); });
-		}
+		// if (result.length === 0){
+		// 	this.findInSetqs(doc, ucName).forEach(x => { result.push(x); });
+		// }
 		return result;
 	}
 


### PR DESCRIPTION
**Objective**
This is an update to the DocumentManager to persist/recycle more data. It was decided during the DefinitionProvider PR #45 that something had to be done about about the excessively expensive `ReadonlyDocument.atomsForest` being regenerated more often than it needed to be.

**Abstraction/Implementation**
This change involves a major emphasis on tracking pairs ReadonlyDocument's & vscode.TextDocuments and performing very cheap checks to detect when the ReadonlyDocument is out of date. It uses a set of flags to specify the various contextual applications. This will inevitably make a ReadonlyDocument qualify for up to 4 queries
- Currently Active Document
- Opened
- Project
- Workspace

However, the expensive parts should now be completely recycled and very cheap checks are in place to avoid the excessive parts of that **potential** duplication. From what I can tell, nothing should ever go through all 4 in expensive ways because any one would have passed the cheap pre-check, had the expensive work done and never moved on to the others.

The original version of this did a lot better job of purging dead data, but I believe this will at least make it inaccessible. This is notable for file renames and deletions performed directly in a OS file explorer. In theory, this is removing the flags that qualify them for various queries, but not necessarily removing the reference entirely across all possible situations. I believe the actions performed in the vscode workspace itself would do proper data purging purging though.

This also removed the PRJ embedded ReadonlyDocument property. Everything is demand queried from the DocumentManager when applicable, but persisted so it can efficiently serve it back next time. The cheap pre-check added in the DefinitionProvider and the fact that ReadonlyDocument creation is also quite cheap should adequately compensate for this. Note that PRJ's being opened/closed is probably the biggest issue with persisted dead data. Since the the ProjectTree's `Instance()` is always used to produce the "_single source of truth_" of fspath keys this should not actually produce erroneous PRJ references, but it has no mechanism for getting rid of the old ones. I'd like to maintain a maximum separation between the Document Manager and the Project Manager if we can.

Removed the attempts to persist data across workspace changes. From what I can tell, this was an exercise of futility. I tried multiple tests to verify it was working and kept eventually winding up with an empty `_cached` property. For example the current arrangement of the `initialize()` method that setups the cache isn't even clearing it anymore and all references are still disappearing after any action that changes the workspace.

Honestly the _documents.ts_ is vastly more clustered than it used to be since it is now handling various edge cases and was massively changed. So, I may be easier to perform your first review without the Adds/Deletes turned on.

**Tests Passed**
I kind of just described them above by identifying the potential known issues. I did run this with the F12 on a Workspace only, a PRJ only and a Workspace/PRJ hybrid.

**Screenshots**
Not Applicable