### PR TITLE
make correct package for vsix file in Github CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 
 
 ##### Screen shot
-<!-- GIF screen shot is prefered, this helps reviewers and testers understand what's the behavior changed -->
+<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Build
         run: |
-          gulp build
-          gulp package
+          python pack.py
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/pack.py
+++ b/pack.py
@@ -11,8 +11,8 @@ import sys
 
 def init():
     print("===============================================")
-    print("             try to install gulp-cli globally")
-    os.system("npm install --global gulp-cli") # nosec
+    print("             try to install gulp-cli")
+    os.system("npm install gulp-cli") # nosec
 
     os.system("npm install --unsafe-perm") # nosec
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "autolispext",
 	"displayName": "AutoCAD AutoLISP Extension",
 	"description": "This is a vscode extension for AutoCAD AutoLISP",
-	"version": "1.3.0",
+	"version": "1.3.4",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"bugs": {
 		"url": "https://github.com/Autodesk-AutoCAD/AutoLispExt/issues"


### PR DESCRIPTION
##### Objective
Github CI didn't package the visx file correctly, it needs to call the pack.py to copy some utility files to correct location.

##### Abstractions
In the pack.py it runs the `npm install`, and copy some utilities files for example the search tool exe files to the correct locations, then `gulp package `can make an expected vsix file for us. So it means that the several pre-release packages we made in CI are not correct. (I will do house keeping latter).

I also make the gulp to install it locally instead of globally, because CI machine to complains that it has no access to some global path.

##### Tests performed
Checked the PR preflight messages that there is no warning to run the pack.py.

##### Screen shot
Not applicable for this PR