### PR TITLE
fix the CI to publish vsix package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./autolispext-${{ steps.update_version.outputs.VERSION }}.vsix
-          asset_name: autolispext-${{ steps.update_version.outputs.VERSION }}.vsix
+          asset_path: ./autolispext.vsix
+          asset_name: autolispext.vsix
           asset_content_type: application/zip


### PR DESCRIPTION
##### Objective
It looks like after this PR https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/63 the CI complains that it can not find the vsix file to do publish:
 Error: ENOENT: no such file or directory, stat './autolispext-1.3.5-da09c7ad1cc9499079d091fc510a798476d8f805.0.vsix'

More details messages see CI page: https://github.com/Autodesk-AutoCAD/AutoLispExt/runs/1692115357

##### Abstractions
To fix the issue I tried to change the main.yml file to publish the `autolispext.vsix` instead of the one with the commit ID package.

##### Tests performed


##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
