### PR TITLE
refine CHANGELOG and fix online help bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## [1.4.0] - 2020-09-21
+## [1.4.0] - 2021-01-20
 a. Added Right Click -> 'Open Online Help' feature. This makes it possible for users to quickly access official documentation on a selected symbol.
+b. Support to insert custom regions.
+c. F12 "Go to definition" support.
+d. Fix DCL comments issue and other minor bugs.
 
-b. Online Help GUID targets were provided by a new data source (webHelpAbstraction.json) that will likely be used to provide future intellisense enhancements
-
-c. Fixed a bug with DCL comments. Both single line and Block comments should now be working.
-
+## [1.3.2] - 2020-12-17
+Remove the call to the deprecated vscode APIs
 
 ## [1.3.0] - 2020-06-12
 a.	Support AutoLISP project editing. Support find and replace in the open project.

--- a/extension/src/help/openWebHelp.ts
+++ b/extension/src/help/openWebHelp.ts
@@ -148,7 +148,7 @@ class WebHelpEntity {
 
 	static getDefaultHelpLink(): string {
 		let lang: string = WebHelpEntity.getLanguageUrlDomain();
-		let year: number = new Date().getFullYear() + 1;
+		let year: number = new Date().getFullYear();
 		return "https://help.autodesk.com/view/OARX/" + year.toString() + lang;
 	}
 


### PR DESCRIPTION
##### Objective
In this commit I want to fix the online help bug, because the latest AutoCAD has not been released, so the ACAD2022 help can not get. And I also refined the changelog text.

##### Abstractions
Our tester complains these two issues to us that the "online help" is broken at this point that the new AutoCAD 2022 has not been released. And the change log text is also not correct. So in this commit I aimed to resolve those two issues.

##### Tests performed
- to test the "Online help" can work well for built in keywords

##### Screen shot
Not applicable for this PR