### PR TITLE
fix the regression to do LAUNCH debug and it has a prompt dialog in ACAD

### DIFF
--- a/DevREADME.md
+++ b/DevREADME.md
@@ -3,12 +3,14 @@
 AutoCAD Lisp Extension is a vscode extension for debug AutoCAD AutoLISP. The Extension plays the roles of both debug adapter and language server which could enable you debug lisp with AutoCAD. The following description is for developers.
 
 ## How to setup the Dev env and compile the code
-
-You could do all the steps in the script pack.py, it is python2; or run it directly:
+Firstly you should make sure you have installed python and NodeJS.
+Then you could do all the steps in the script pack.py, it is python2; or run it directly:
 ```
 cd AutoLispExt
+npm install --global gulp-cli
 python pack.py
 ```
+
 ### How to compile the codes
 The script pack.py will copy some utility files to correct location for making package. After run that script and then change some TS codes, you can also use the follow command to compile codes simply:
 ```

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -36,7 +36,8 @@ class LaunchDebugAdapterExecutableFactory
     let productStartCommand = ProcessPathCache.globalProductPath;
     let productStartParameter = ProcessPathCache.globalParameter;
 
-    const args = ["--", productStartCommand, productStartParameter];
+    let args = ["--", productStartCommand, productStartParameter];
+    if (productStartParameter == null) args = ["--", productStartCommand];
     return new vscode.DebugAdapterExecutable(lispadapterpath, args);
   }
 }


### PR DESCRIPTION
##### Objective
In this submission I want to fix the regression to do launch debug, then ACAD has a prompt message. This is the bug logged by our tester:
Reproducible Steps:
1. Download the latest extension from
https://github.com/Autodesk-AutoCAD/AutoLispExt/releases/tag/v1.3.5-e89e0583505fa944bf959348745e8caf8ff6b47c.0

2. Open a lisp in vscode
3. Press F5 and choose launch
 Actual Result:
 Sequoia will pop up a below message dialog
AutoCAD Message
Cannot find the specified drawing file.
Please verify that the file exists.
OK


##### Abstractions
I think this bug is introduced by this PR https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/55
If user doesn't fill any thing in the `Paramter ` field in the extension setting, then it will fill null to API `vscode.DebugAdapterExecutable`. It looks like this API will translate null to some bad file parameter inside to ACAD.

I think this PR this PR https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/55 introduced the point that the parameter can be null. So it introduced this issue.

##### Tests performed
 - retest the bug mentioned above, and test debug launch mode with/without start parameters.
 
![image](https://user-images.githubusercontent.com/68938334/105286420-333fd780-5bf1-11eb-8a21-9e47afbb5a78.png)


##### Screen shot
Not applicable, only bugfix