### PR TITLE
It should not change the version in package.json file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.1.2
 
-      - name: Update version
+      - name: get version
         id: update_version
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
           $version=node -e console.log(require('./package.json').version);
-          $version=$version.substring(1)+"-"+${{github.sha}}
+          $version=$version.substring(1)+"-"+[string]${{github.sha}}
           echo "::set-output name=VERSION::$version"
         shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         id: update_version
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
-          $version=node -e console.log(require('./package.json').version);
+          $version=grep '"version":' package.json | cut -d" -f4
           $version=$version.substring(1)+"-${{github.sha}}"
           echo "::set-output name=VERSION::$version"
         shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
           $version=node -e console.log(require('./package.json').version);
-          $version=$version.substring(1)+"-"+[string]${{github.sha}}
+          $version=$version.substring(1)+"-${{github.sha}}"
           echo "::set-output name=VERSION::$version"
         shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           $version=npm version prerelease --no-git-tag-version --preid=${{github.sha}}
           $version=$version.substring(1)
-          echo "::set-output name=VERSION::$version"
         shell: pwsh
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,9 @@ jobs:
         id: update_version
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
-          $version=npm version prerelease --no-git-tag-version --preid=${{github.sha}}
-          $version=$version.substring(1)
+          $version=node -e console.log(require('./package.json').version);
+          $version=$version.substring(1)+"-"+${{github.sha}}
+          echo "::set-output name=VERSION::$version"
         shell: pwsh
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         id: update_version
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
-          $version=grep '"version":' package.json | cut -d" -f4
+          $version=node -p "require('./package.json').version"
           $version=$version.substring(1)+"-${{github.sha}}"
           echo "::set-output name=VERSION::$version"
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Your feedback is highly appreciated! Should you have any suggestions, please cre
     * Find & Search in a project
 
 ## Getting started
-- Step 1. Install a supported AutoCAD release on your system.
+- Step 1. Install a supported AutoCAD release on your system. 
 - Step 2. Install this extension.
 - Step 3. Open a folder that contains the AutoLISP source (LSP) files you want to work on. Or open an Autolisp project file via VSCODE side bar.
 - Step 4. Open a LSP file to modify or debug.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Your feedback is highly appreciated! Should you have any suggestions, please cre
     * Document/selection formatting using narrow or wide style
     * Auto indent
     * Easy access to online documentation through the context menu (selection sensitive)
+    * Go to definition
+    * Insert code region
 
 3. AutoLISP Project
     * Open a project (.prj)
@@ -38,7 +40,7 @@ Your feedback is highly appreciated! Should you have any suggestions, please cre
 ## Getting started
 - Step 1. Install a supported AutoCAD release on your system.
 - Step 2. Install this extension.
-- Step 3. Open a folder that contains the AutoLISP source (LSP) files you want to work on.
+- Step 3. Open a folder that contains the AutoLISP source (LSP) files you want to work on. Or open an Autolisp project file via VSCODE side bar.
 - Step 4. Open a LSP file to modify or debug.
 - Step 5. Choose a debug configuration and start debugging the current LSP file.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "autolispext",
 	"displayName": "AutoCAD AutoLISP Extension",
 	"description": "This is a vscode extension for AutoCAD AutoLISP",
-	"version": "1.3.4",
+	"version": "1.3.6",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"bugs": {
 		"url": "https://github.com/Autodesk-AutoCAD/AutoLispExt/issues"


### PR DESCRIPTION
##### Objective
This is a commit to CI that it should not modify the package.json's version field 
I don't want the version as:
![image](https://user-images.githubusercontent.com/68938334/106084463-5c181d80-6159-11eb-938c-97fc0ba73762.png)

I want the real version has no such SHA postfix, but the tag it created in github has the SHA commit postfix.

##### Abstractions
This clean up is also a commit to prepare releasing the version 1.4.0 in recent weeks.

##### Tests performed


##### Screen shot
Not applicable