### PR TITLE
refine the tag created version it missed the major version number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions
         run: |
           $version=node -p "require('./package.json').version"
-          $version=$version.substring(1)+"-${{github.sha}}"
+          $version=$version+"-${{github.sha}}"
           echo "::set-output name=VERSION::$version"
         shell: pwsh
 


### PR DESCRIPTION
##### Objective
I want to fix the issue that the github tag added by CI missed the major version.
![image](https://user-images.githubusercontent.com/68938334/106226695-baf59980-6222-11eb-99ad-2a2285543961.png)


##### Abstractions
<!-- How to do the changes, or the algorithm -->

##### Tests performed
it is hard to test, it should verify by CI

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
