### PR TITLE
fix bug that all the TS file localization string don't work

### DIFF
--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -1,9 +1,11 @@
 import * as vscode from "vscode";
+import * as nls from 'vscode-nls';
 import { AutoLispExt } from './extension';
 import { openWebHelp } from './help/openWebHelp';
 import { showErrorMessage } from './project/projectCommands';
 import { AutolispDefinitionProvider } from './providers/gotoProvider';
 
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerCommands(context: vscode.ExtensionContext){
 
@@ -14,7 +16,7 @@ export function registerCommands(context: vscode.ExtensionContext){
 		}
 		catch (err) {
 			if (err){
-				let msg = AutoLispExt.localize("autolispext.help.commands.openWebHelp", "Failed to load the webHelpAbstraction.json file");
+				let msg = localize("autolispext.help.commands.openWebHelp", "Failed to load the webHelpAbstraction.json file");
 				showErrorMessage(msg, err);
 			}
 		}
@@ -30,7 +32,7 @@ export function registerCommands(context: vscode.ExtensionContext){
 		}
 		catch (err) {
 			if (err){
-				let msg = AutoLispExt.localize("autolispext.commands.addFoldingRegion", "Failed to insert snippet");
+				let msg = localize("autolispext.commands.addFoldingRegion", "Failed to insert snippet");
 				showErrorMessage(msg, err);
 			}
 		}

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -4,13 +4,13 @@ import * as Resources from "./resources";
 import { Disposable } from 'vscode-languageclient';
 import { DocumentManager } from './documents';
 
-// This is a singleton class
+
 export class ContextManager{
 	private _ctx: vscode.ExtensionContext;
 	private _docManager: DocumentManager;
 	
-	localize: nls.LocalizeFunc = nls.config({ messageFormat: nls.MessageFormat.file })();
-
+	localize = nls.config({ messageFormat: nls.MessageFormat.file })();	
+	
 	get Context(): vscode.ExtensionContext { 
 		return this._ctx; 
 	}

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
 import * as Net from 'net';
 import * as os from 'os';
-import { AutoLispExt } from './extension';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 import { pickProcess } from './process/acadPicker';
 import { calculateABSPathForDAP } from './platform';
@@ -9,8 +11,8 @@ import { existsSync } from 'fs';
 import { ProcessPathCache } from './process/processCache';
 import { DiagnosticsCtrl } from './diagnosticsCtrl';
 
-let strNoADPerr: string = AutoLispExt.localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
-let strNoACADerr: string = AutoLispExt.localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
+let strNoADPerr: string = localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
+let strNoACADerr: string = localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
 let acadPid2Attach = -1;
 
 const attachCfgName = 'AutoLISP Debug: Attach';
@@ -95,7 +97,7 @@ export function registerLispDebugProviders(context: vscode.ExtensionContext) {
                 setDefaultAcadPid(-1);
             }
             else if (event.event === "acadnosupport") {
-                let msg = AutoLispExt.localize("autolispext.debug.acad.nosupport",
+                let msg = localize("autolispext.debug.acad.nosupport",
                     "This instance of AutoCAD doesn’t support debugging AutoLISP files, use a release later than AutoCAD 2020.");
                 vscode.window.showErrorMessage(msg);
             }
@@ -133,24 +135,24 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
             let productPath = getExtensionSettingString(LAUNCH_PROC);
 
             if (!productPath) {
-                let info = AutoLispExt.localize("autolispext.debug.launchjson.path",
+                let info = localize("autolispext.debug.launchjson.path",
                     "Specify the absolute path to the product with the Path attribute of the launch.json file.");
                 vscode.window.showInformationMessage(info);
                 let platform = os.type();
                 if (platform === 'Windows_NT') {
-                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.win",
+                    let msg = localize("autolispext.debug.prod.path.win",
                         "Specify the absolute path for the product. For example, C://Program Files//Autodesk//AutoCAD//acad.exe.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
                 else if (platform === 'Darwin') {
-                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.osx",
+                    let msg = localize("autolispext.debug.prod.path.osx",
                         "Specify the absolute path for the product. For example, /Applications/Autodesk/AutoCAD.app/Contents/MacOS/AutoCAD.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
                 else {
-                    let msg = AutoLispExt.localize("autolispext.debug.prod.path.other", "Specify the absolute path for the product.");
+                    let msg = localize("autolispext.debug.prod.path.other", "Specify the absolute path for the product.");
                     productPath = await vscode.window.showInputBox({ placeHolder: msg });
                     rememberLaunchPath(productPath);
                 }
@@ -212,7 +214,7 @@ class LispAttachConfigurationProvider implements vscode.DebugConfigurationProvid
         ProcessPathCache.clearProductProcessPathArr();
         let processId = await pickProcess(false, acadPid2Attach);
         if (!processId) {
-            let msg = AutoLispExt.localize("autolispext.debug.noprocess.eror", "No process for which to attach could be found.");
+            let msg = localize("autolispext.debug.noprocess.eror", "No process for which to attach could be found.");
             return vscode.window.showInformationMessage(msg).then(_ => {
                 return undefined;	// abort attach
             });

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,28 +1,35 @@
 
 'use strict';
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
-import { ContextManager } from "./context";
-// moved singleton AutoLispExt constructor ahead of 'our' other imports to create nls.localize() before they cause a null reference error
-export const AutoLispExt: ContextManager = new ContextManager();
+
+import {
+	LanguageClient
+} from 'vscode-languageclient';
+
 
 import * as Diagnostics from './diagnosticsCtrl';
 import { onUriRequested } from './uriHandler';
+
 import * as formatProviders from './format/formatProviders';
 import * as autoCompletionProvider from "./completion/autocompletionProvider";
 import * as statusBar from "./statusbar";
 import * as autoIndent from './format/autoIndent';
+import { ContextManager } from "./context";
 import * as DebugProviders from "./debug";
 import { registerProjectCommands } from "./project/projectCommands";
 import { registerCommands } from "./commands";
 import { loadAllResources } from "./resources";
+import * as nls from 'vscode-nls';
 
+// The example uses the file message format.
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+export const AutoLispExt: ContextManager = new ContextManager();
 let client: LanguageClient;
 
 loadAllResources();
 
 export function activate(context: vscode.ExtensionContext) {
-	AutoLispExt.initialize(context); 
+	AutoLispExt.initialize(context);	
 
 	//-----------------------------------------------------------
 	//1. lisp autoformat

--- a/extension/src/format/formatProviders.ts
+++ b/extension/src/format/formatProviders.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { LispFormatter } from './formatter';
-import * as utils from "../utils";
-import { AutoLispExt } from '../extension';
-
+import { LispFormatter } from './formatter'
+import * as utils from "../utils"
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerDocumentFormatter() {
     vscode.languages.registerDocumentFormattingEditProvider(['autolisp', 'lisp'], {
@@ -13,7 +13,7 @@ export function registerDocumentFormatter() {
             let currentLSPDoc = activeTextEditor.document.fileName;
             let ext = currentLSPDoc.substring(currentLSPDoc.length - 4, currentLSPDoc.length).toUpperCase();
             if (ext === ".DCL") {
-                let msg = AutoLispExt.localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
+                let msg = localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
                 vscode.window.showInformationMessage(msg);
                 return [];
             }
@@ -33,12 +33,12 @@ export function registeSelectionFormatter() {
             let currentLSPDoc = activeTextEditor.document.fileName;
             let ext = currentLSPDoc.substring(currentLSPDoc.length - 4, currentLSPDoc.length).toUpperCase();
             if (ext === ".DCL") {
-                let msg = AutoLispExt.localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
+                let msg = localize("autolispext.format.notsupport.dcl", "Command doesn't support DCL files.");
                 vscode.window.showInformationMessage(msg);
                 return [];
             }
             if (activeTextEditor.selection.isEmpty) {
-                let msg = AutoLispExt.localize("autolispext.format.selectionlines", "First, select the lines of code to format.");
+                let msg = localize("autolispext.format.selectionlines", "First, select the lines of code to format.");
                 vscode.window.showInformationMessage(msg);
             }
 

--- a/extension/src/format/formatter.ts
+++ b/extension/src/format/formatter.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
+
 import { Sexpression } from "./sexpression";
 import { LispParser } from "./parser";
-import { AutoLispExt } from '../extension';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class LispFormatter {
 
@@ -58,7 +60,7 @@ export class LispFormatter {
 
                 let formatstr = lispLists.formatting(startColumn, linefeed);
                 if (formatstr.length == 0) {
-                    let msg = AutoLispExt.localize("autolispext.formatter.errors", "It meets some errors when formatting");
+                    let msg = localize("autolispext.formatter.errors", "It meets some errors when formatting");
                     throw new Error(msg);
                 }
 

--- a/extension/src/process/acadPicker.ts
+++ b/extension/src/process/acadPicker.ts
@@ -13,9 +13,11 @@ import { basename } from 'path';
 import { getProcesses } from './processTree';
 import {ProcessPathCache} from "./processCache";
 import { calculateACADProcessName } from '../platform';
-import { activeDocHasValidLanguageId } from '../utils';
-import { AutoLispExt } from '../extension';
+import { acitiveDocHasValidLanguageId } from '../utils';
 
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 interface ProcessItem extends vscode.QuickPickItem{
     pidOrPort:string;
     sortKey:number;
@@ -24,11 +26,11 @@ interface ProcessItem extends vscode.QuickPickItem{
 function getProcesspickerPlaceHolderStr(){
 	let platform = os.type();
 	if(platform === 'Windows_NT'){
-		return AutoLispExt.localize('autolispext.pickprocess.acad.win', "Pick the process to attach. Make sure AutoCAD, or one of the specialized toolsets, is running. Type acad and select it from the list.");
+		return localize('autolispext.pickprocess.acad.win', "Pick the process to attach. Make sure AutoCAD, or one of the specialized toolsets, is running. Type acad and select it from the list.");
 	}else if(platform === 'Darwin'){
-		return AutoLispExt.localize('autolispext.pickprocess.acad.osx', "Pick the process to attach. Make sure AutoCAD is running. Type AutoCAD and select it from the list.");
+		return localize('autolispext.pickprocess.acad.osx', "Pick the process to attach. Make sure AutoCAD is running. Type AutoCAD and select it from the list.");
 	}else{
-		return AutoLispExt.localize('autolispext.pickprocess.acad.other', "Pick the process to attach");
+		return localize('autolispext.pickprocess.acad.other', "Pick the process to attach");
 	}
 }
 
@@ -54,7 +56,7 @@ export function pickProcess(ports:any, defaultPid: number): Promise<string | nul
 		let choosedItem =  vscode.window.showQuickPick(items, options).then(item => item ? item.pidOrPort : null);
 		return choosedItem;
 	}).catch(err => {
-		let chooseItem = vscode.window.showErrorMessage(AutoLispExt.localize('autolispext.pickprocess.pickfailed', "Process picker failed ({0})", err.message), { modal: true }).then(_ => null);
+		let chooseItem = vscode.window.showErrorMessage(localize('autolispext.pickprocess.pickfailed', "Process picker failed ({0})", err.message), { modal: true }).then(_ => null);
 		return chooseItem;
 	});
 }
@@ -74,7 +76,7 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 		if(ProcessPathCache.globalAcadNameInUserAttachConfig){
 			processName = ProcessPathCache.globalAcadNameInUserAttachConfig;
 		}
-		else if (vscode.window.activeTextEditor && activeDocHasValidLanguageId()) {
+		else if (vscode.window.activeTextEditor && acitiveDocHasValidLanguageId()) {
 			//read attach configuration from launch.json
 			let configurations:[] = vscode.workspace.getConfiguration("launch", vscode.window.activeTextEditor.document.uri).get("configurations");
 			let attachLispConfig;
@@ -113,14 +115,14 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 
 		if (usePort) {
 			if (protocol === 'inspector') {
-				description = AutoLispExt.localize('autolispext.pickprocess.process.id.port', "process id: {0}, debug port: {1}", pid, port);
+				description = localize('autolispext.pickprocess.process.id.port', "process id: {0}, debug port: {1}", pid, port);
 			} else {
-				description = AutoLispExt.localize('autolispext.pickprocess.process.id.legacy', "process id: {0}, debug port: {1} (legacy protocol)", pid, port);
+				description = localize('autolispext.pickprocess.process.id.legacy', "process id: {0}, debug port: {1} (legacy protocol)", pid, port);
 			}
 			pidOrPort = `${protocol}${port}`;
 		} else {
 			if (protocol && port > 0) {
-				description = AutoLispExt.localize('autolispext.pickprocess.process.port.singal', "process id: {0}, debug port: {1} ({2})", pid, port, 'SIGUSR1');
+				description = localize('autolispext.pickprocess.process.port.singal', "process id: {0}, debug port: {1} ({2})", pid, port, 'SIGUSR1');
 				pidOrPort = `${pid}${protocol}${port}`;
 			} else {
 				// no port given
@@ -136,7 +138,7 @@ function listProcesses(ports: boolean): Promise<ProcessItem[]> {
 
 				if(addintolist){
 					ProcessPathCache.addGlobalProductProcessPathArr(executablePath, pid);
-					description = AutoLispExt.localize('autolispext.pickprocess.process.id.singal', "process id: {0} ({1})", pid, 'SIGUSR1');
+					description = localize('autolispext.pickprocess.process.id.singal', "process id: {0} ({1})", pid, 'SIGUSR1');
 					pidOrPort = pid.toString();
 				}
 			}

--- a/extension/src/project/addFile2Project.ts
+++ b/extension/src/project/addFile2Project.ts
@@ -1,12 +1,15 @@
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 import { ProjectTreeProvider, isFileAlreadyInProject, hasFileWithSameName } from './projectTree';
-import { AutoLispExt } from '../extension';
-import * as path from 'path';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+
+import * as path from 'path'
 
 export async function AddFile2Project(fileList?: vscode.Uri[]) {
     try {
         if (ProjectTreeProvider.hasProjectOpened() == false) {
-            let msg = AutoLispExt.localize("autolispext.project.addfile.openproject", "A project must be open before you can add a file.");
+            let msg = localize("autolispext.project.addfile.openproject", "A project must be open before you can add a file.");
             return Promise.reject(msg);
         }
 
@@ -18,7 +21,7 @@ export async function AddFile2Project(fileList?: vscode.Uri[]) {
         for (let file of selectedFiles) {
             let fileUpper = file.fsPath.toUpperCase();
             if (fileUpper.endsWith(".LSP") == false) {
-                let msg = AutoLispExt.localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
+                let msg = localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
                 return Promise.reject(msg);
             }
 
@@ -27,19 +30,19 @@ export async function AddFile2Project(fileList?: vscode.Uri[]) {
                 //Legacy IDE doesn't allow user to add hello.lsp.lsp into a project, but if there happen to be a file
                 //  named hello.lsp, it will add hello.lsp into project, and this is wrong.
                 //To keep consistency with legacy IDE, we have to reject files of this kind.
-                let msg = AutoLispExt.localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
+                let msg = localize("autolispext.project.addfile.onlylspallowed", "Only LSP files are allowed.");
                 return Promise.reject(msg);
             }
 
             if (isFileAlreadyInProject(file.fsPath, ProjectTreeProvider.instance().projectNode)) {
-                let msg = AutoLispExt.localize("autolispext.project.addfile.filealreadyexist", "File already exists in this project: ");
+                let msg = localize("autolispext.project.addfile.filealreadyexist", "File already exists in this project: ");
                 vscode.window.showInformationMessage(msg + file.fsPath);
 
                 continue;
             }
 
             if(hasFileWithSameName(file.fsPath, ProjectTreeProvider.instance().projectNode)) {
-                let msg = AutoLispExt.localize("autolispext.project.addfile.samenameexist", "File with the same name already exists in this project: ");
+                let msg = localize("autolispext.project.addfile.samenameexist", "File with the same name already exists in this project: ");
                 vscode.window.showInformationMessage(msg + path.basename(file.fsPath));
 
                 continue;
@@ -76,7 +79,7 @@ function hasMultipleExtensions(filePath:string):boolean {
 }
 
 async function SelectLspFiles() {
-    let label = AutoLispExt.localize("autolispext.project.addfile.openlabel", "Add to Project");
+    let label = localize("autolispext.project.addfile.openlabel", "Add to Project");
     const options: vscode.OpenDialogOptions = {
         //TBD: globalize
         canSelectMany: true,

--- a/extension/src/project/checkUnsavedChanges.ts
+++ b/extension/src/project/checkUnsavedChanges.ts
@@ -2,7 +2,9 @@ import { SaveProject } from './saveProject';
 import { ProjectTreeProvider } from './projectTree';
 import * as vscode from 'vscode';
 import { pathEqual } from '../utils';
-import { AutoLispExt } from '../extension';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 //return false if no project is opened or there are no unsaved changes or user select "Save" or "Don't Save" the changes
 //return true if there are unsaved changes and user select "Cancel" or just close the dialog
@@ -26,9 +28,9 @@ export async function CheckUnsavedChanges(): Promise<boolean> {
     
     // prompt user if there are unsaved changes
     if (root.projectModified || unsavedFiles.length > 0) {
-        let msg = AutoLispExt.localize("autolispext.project.checkunsavedchanges.message", "Unsaved changes found with the project or the files in the project.\nDo you want to save the changes?");
-        let save = AutoLispExt.localize("autolispext.project.checkunsavedchanges.save", "Save");
-        let dontSave = AutoLispExt.localize("autolispext.project.checkunsavedchanges.dontsave", "Don't Save");
+        let msg = localize("autolispext.project.checkunsavedchanges.message", "Unsaved changes found with the project or the files in the project.\nDo you want to save the changes?");
+        let save = localize("autolispext.project.checkunsavedchanges.save", "Save");
+        let dontSave = localize("autolispext.project.checkunsavedchanges.dontsave", "Don't Save");
         const selection = await vscode.window.showWarningMessage(msg, {modal: true}, save, dontSave);
         if (!selection) {
             return true;

--- a/extension/src/project/createProject.ts
+++ b/extension/src/project/createProject.ts
@@ -1,13 +1,16 @@
 
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from 'path'
+import { AutoLispExt } from '../extension';
 import { ProjectNode, LspFileNode } from './projectTree';
 import { ProjectDefinition } from './projectDefinition';
-import { AutoLispExt } from '../extension';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export async function getNewProjectFilePath() {
-    let label = AutoLispExt.localize("autolispext.project.createproject.createlabel", "Create");
+    let label = localize("autolispext.project.createproject.createlabel", "Create");
     const options: vscode.SaveDialogOptions = {
         //TBD: globalize
         saveLabel: label,
@@ -32,7 +35,7 @@ export async function getNewProjectFilePath() {
 export async function createProject(prjFilePath: string) {
     let prjPathUpper = prjFilePath.toUpperCase();
     if (prjPathUpper.endsWith(".PRJ") == false) {
-        let msg = AutoLispExt.localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
+        let msg = localize("autolispext.project.createproject.onlyprjallowed", "Only PRJ files are allowed.");
         return Promise.reject(msg)
     }
 

--- a/extension/src/project/excludeFile.ts
+++ b/extension/src/project/excludeFile.ts
@@ -1,10 +1,12 @@
 import { LspFileNode, ProjectTreeProvider } from './projectTree';
 import { pathEqual } from '../utils';
-import { AutoLispExt } from '../extension';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export async function excludeFromProject(selected: LspFileNode) {
     if (ProjectTreeProvider.hasProjectOpened() == false) {
-        let msg = AutoLispExt.localize("autolispext.project.excludefile.openproject", "A project must be open before you can exclude a file.");
+        let msg = localize("autolispext.project.excludefile.openproject", "A project must be open before you can exclude a file.");
         return Promise.reject(msg);
     }
 
@@ -21,7 +23,7 @@ export async function excludeFromProject(selected: LspFileNode) {
     }
 
     if (index2Del < 0) {
-        let msg = AutoLispExt.localize("autolispext.project.excludefile.filenotexist", "File to exclude doesn't exist in the current project.");
+        let msg = localize("autolispext.project.excludefile.filenotexist", "File to exclude doesn't exist in the current project.");
         return Promise.reject(msg);
     }
 

--- a/extension/src/project/findReplace/applyReplacement.ts
+++ b/extension/src/project/findReplace/applyReplacement.ts
@@ -1,13 +1,15 @@
 import * as fs from 'fs-extra';
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
+
 import { FileNode } from './searchTree';
-import { getDocument } from '../../utils';
-import { AutoLispExt } from '../../extension';
+import { getTmpFilePath, getDocument } from '../../utils';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export async function applyReplacementInFile(filePlan: FileNode) {
     try {
         if (fs.existsSync(filePlan.filePath) == false) {
-            filePlan.errorInReplace = AutoLispExt.localize("autolispext.project.findreplace.applyreplacement.filenotexist", "File doesn't exist.");
+            filePlan.errorInReplace = localize("autolispext.project.findreplace.applyreplacement.filenotexist", "File doesn't exist.");
             return;
         }
 
@@ -79,7 +81,7 @@ async function applyChangeInEditor(filePath: string, fileContent: string) {
 
         let succ = await vscode.workspace.applyEdit(edit);
         if (!succ) {
-            let msg = AutoLispExt.localize("autolispext.project.findreplace.applyreplacement.replacetextfailed", "Failed to replace text: ");
+            let msg = localize("autolispext.project.findreplace.applyreplacement.replacetextfailed", "Failed to replace text: ");
             throw new Error(msg + filePath);
         }
 

--- a/extension/src/project/findReplace/clearResults.ts
+++ b/extension/src/project/findReplace/clearResults.ts
@@ -1,7 +1,9 @@
 import { SearchTreeProvider, SummaryNode } from './searchTree';
 import { SearchOption } from './options';
-import * as vscode from 'vscode';
-import { AutoLispExt } from '../../extension';
+
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function clearSearchResults() {
     SearchTreeProvider.instance.clear();
@@ -29,7 +31,7 @@ let isSearching: boolean = false;
 //this method is expected to never throw error, as it will be the first method to call in many use cases
 export function getWarnIsSearching(): boolean {
     if (isSearching) {
-        let msg = AutoLispExt.localize("autolispext.project.findReplace.clearresults.issearching", "A search is in progress, wait until the current search has completed and try again.");
+        let msg = localize("autolispext.project.findReplace.clearresults.issearching", "A search is in progress, wait until the current search has completed and try again.");
         vscode.window.showInformationMessage(msg);
         return true;
     }

--- a/extension/src/project/findReplace/findInProject.ts
+++ b/extension/src/project/findReplace/findInProject.ts
@@ -3,28 +3,31 @@ import { ProjectNode, ProjectTreeProvider } from '../projectTree';
 import { findInFile } from './ripGrep';
 import { FileNode, FindingNode, SearchTreeProvider, SummaryNode } from './searchTree';
 import { saveOpenDoc2Tmp } from '../../utils';
-import * as vscode from 'vscode';
+
+import * as vscode from 'vscode'
 import * as os from 'os';
 import { applyReplacementInFile } from './applyReplacement';
 import { setIsSearching } from './clearResults';
-import { AutoLispExt } from '../../extension';
+import * as nls from 'vscode-nls';
 import { detectEncoding } from './encoding';
-import * as fs from 'fs-extra';
-import * as osLocale from 'os-locale';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
+const fs = require('fs-extra')
+
+const osLocale = require('os-locale');
 const encodings = new Map([["zh-CN", "gb2312"], ["zh-TW", "big5"], ["ja-JP", "shift-jis"], ["ko-KR", "ksc5601"]]);
 
 export async function findInProject() {
     //check if there's a opened project
     if (ProjectTreeProvider.hasProjectOpened() == false) {
-        let msg = AutoLispExt.localize("autolispext.project.find.openproject", "A project must be open before you can search for a text string.");
+        let msg = localize("autolispext.project.find.openproject", "A project must be open before you can search for a text string.");
         vscode.window.showInformationMessage(msg);
         return;
     }
 
     //get search option
-    let title = AutoLispExt.localize("autolispext.project.find.title", "Find in Project");
-    let hint = AutoLispExt.localize("autolispext.project.find.hint", "Type a text string to find, and press Enter.");
+    let title = localize("autolispext.project.find.title", "Find in Project");
+    let hint = localize("autolispext.project.find.hint", "Type a text string to find, and press Enter.");
     let opt = await getSearchOption(title, hint);
     if (opt.isKeywordProvided() == false)
         return;
@@ -52,7 +55,7 @@ export class FindInProject {
     public async execute(searchOption: SearchOption, prjNode: ProjectNode) {
         if (os.platform() == 'win32') {
             if (os.arch() != 'x64') {
-                let msg = AutoLispExt.localize("autolispext.project.find.supportos", "Find & Replace is supported only on 64-bit systems.");
+                let msg = localize("autolispext.project.find.supportos", "Find & Replace is supported only on 64-bit systems.");
                 return Promise.reject(msg);
             }
         }
@@ -71,7 +74,7 @@ export class FindInProject {
             this.summaryNode.makeTooltip(searchOption, prjNode);
 
             //update the search tree with some progress
-            let summary = AutoLispExt.localize("autolispext.project.find.inprogress", "In progress... ");
+            let summary = localize("autolispext.project.find.inprogress", "In progress... ");
             this.summaryNode.summary = summary;
             SearchTreeProvider.instance.reset(this.resultByFile, this.summaryNode, searchOption);
 
@@ -79,9 +82,9 @@ export class FindInProject {
             let totalFiles = 0;
             let totalLines = 0;
 
-            let found = AutoLispExt.localize("autolispext.project.find.found", "Found ");
-            let lines = AutoLispExt.localize("autolispext.project.find.results", " result(s) in ");
-            let files = AutoLispExt.localize("autolispext.project.find.files", " file(s):");
+            let found = localize("autolispext.project.find.found", "Found ");
+            let lines = localize("autolispext.project.find.results", " result(s) in ");
+            let files = localize("autolispext.project.find.files", " file(s):");
             for (let srcFile of prjNode.sourceFiles) {
                 if (SearchOption.activeInstance.stopRequested)
                     break;
@@ -151,18 +154,18 @@ export class FindInProject {
             }
 
             if (SearchOption.activeInstance.stopRequested) {
-                this.summaryNode.summary = AutoLispExt.localize("autolispext.project.find.stopped", "Find stopped. ");
+                this.summaryNode.summary = localize("autolispext.project.find.stopped", "Find stopped. ");
             } else {
                 this.summaryNode.summary = '';
             }
 
             if (exceedMaxResults) {
-                this.summaryNode.summary += AutoLispExt.localize("autolispext.project.find.exceedmaxresults", "Limit of search results exceeded. Refine your search to narrow down the results. ");
+                this.summaryNode.summary += localize("autolispext.project.find.exceedmaxresults", "Limit of search results exceeded. Refine your search to narrow down the results. ");
             }
 
             if (totalLines <= 0) {
                 if (!exceedMaxResults) {
-                    this.summaryNode.summary += AutoLispExt.localize("autolispext.project.find.noresults", "No results found.");
+                    this.summaryNode.summary += localize("autolispext.project.find.noresults", "No results found.");
                 }
             }
             else {

--- a/extension/src/project/findReplace/openSearchResult.ts
+++ b/extension/src/project/findReplace/openSearchResult.ts
@@ -4,7 +4,8 @@ import { getDocument } from '../../utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ReadonlyDocument } from '../readOnlyDocument';
-import { AutoLispExt } from '../../extension';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: SearchOption) {
 
@@ -17,7 +18,7 @@ export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: 
         const exists = fs.existsSync(finding.filePath);
 
         if (exists == false) {
-            let msg = AutoLispExt.localize("autolispext.project.findreplace.opensearchresult.filenotexist", "File doesn't exist: ");
+            let msg = localize("autolispext.project.findreplace.opensearchresult.filenotexist", "File doesn't exist: ");
             return Promise.reject(msg + finding.filePath);
         }
 
@@ -52,7 +53,7 @@ export async function openSearchResult(clickedTreeItem: FindingNode, searchOpt: 
         if (!doc) {
             doc = ReadonlyDocument.open(finding.filePath);
             if (!doc) {
-                let msg = AutoLispExt.localize("autolispext.project.findreplace.opensearchresult.openfailed", "File couldn't be opened: ");
+                let msg = localize("autolispext.project.findreplace.opensearchresult.openfailed", "File couldn't be opened: ");
                 return Promise.reject(msg + finding.filePath);
             }
         }

--- a/extension/src/project/findReplace/optionButton.ts
+++ b/extension/src/project/findReplace/optionButton.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { IconUris } from '../icons';
 import { SearchOption } from './options';
-import { AutoLispExt } from '../../extension';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class optionButton implements vscode.QuickInputButton {
     public constructor(iconUriOn: vscode.Uri, iconUriOff: vscode.Uri, isOn: boolean,
@@ -34,25 +35,25 @@ export class optionButton implements vscode.QuickInputButton {
 
     public static getButtons() {
         if (!optionButton.matchCaseBtn) {
-            let matchCase = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.matchcase", "Match Case");
+            let matchCase = localize("autolispext.project.findreplace.optionbutton.matchcase", "Match Case");
             optionButton.matchCaseBtn =
                 new optionButton(IconUris.matchCase(true), IconUris.matchCase(false), SearchOption.activeInstance.matchCase,
                     matchCase,
                     optionButton.name_MatchCase);
 
-            let matchWholeWord = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.matchwholeword", "Match Whole Word");
+            let matchWholeWord = localize("autolispext.project.findreplace.optionbutton.matchwholeword", "Match Whole Word");
             optionButton.matchWordBtn =
                 new optionButton(IconUris.matchWord(true), IconUris.matchWord(false), SearchOption.activeInstance.matchWholeWord,
                     matchWholeWord,
                     optionButton.name_MatchWord);
 
-            let regExp = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.regexp", "Use Regular Expression");
+            let regExp = localize("autolispext.project.findreplace.optionbutton.regexp", "Use Regular Expression");
             optionButton.useRegularExprBtn =
                 new optionButton(IconUris.useRegularExpr(true), IconUris.useRegularExpr(false), SearchOption.activeInstance.useRegularExpr,
                     regExp,
                     optionButton.name_UseRegularExpr);
 
-            let closeTooltip = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.close", "Close");
+            let closeTooltip = localize("autolispext.project.findreplace.optionbutton.close", "Close");
             optionButton.closeBtn = new optionButton(IconUris.closeUri(), null, true, closeTooltip, optionButton.name_Close);
         }
 

--- a/extension/src/project/findReplace/options.ts
+++ b/extension/src/project/findReplace/options.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { optionButton } from './optionButton';
 import { IconUris } from '../icons';
-import { AutoLispExt } from '../../extension';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class SearchOption {
     static activeInstance: SearchOption = new SearchOption;//the one bound to search UI
@@ -108,7 +109,7 @@ export async function getString(title: string, hint: string) {
             quickpick.value = '';
             quickpick.ignoreFocusOut = true;
 
-            let closeTooltip = AutoLispExt.localize("autolispext.project.findreplace.optionbutton.close", "Close");
+            let closeTooltip = localize("autolispext.project.findreplace.optionbutton.close", "Close");
             let closeBtn = new optionButton(IconUris.closeUri(), null, true, closeTooltip, optionButton.name_Close);
             quickpick.buttons = [closeBtn];
 

--- a/extension/src/project/findReplace/replaceInProject.ts
+++ b/extension/src/project/findReplace/replaceInProject.ts
@@ -2,24 +2,26 @@ import { SearchTreeProvider } from './searchTree';
 import { FindInProject } from './findInProject';
 import { ProjectTreeProvider } from '../projectTree';
 import { getSearchOption, getString } from './options';
-import * as vscode from 'vscode';
-import { AutoLispExt } from '../../extension';
+
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export async function replaceInProject() {
     if (ProjectTreeProvider.hasProjectOpened() == false) {
-        let msg = AutoLispExt.localize("autolispext.project.findreplace.replace.openproject", "A project must be open before you can replace a text string.");
+        let msg = localize("autolispext.project.findreplace.replace.openproject", "A project must be open before you can replace a text string.");
         vscode.window.showInformationMessage(msg);
         return;
     }
 
     //get find options: keyword, match case, etc.
-    let title = AutoLispExt.localize("autolispext.project.findreplace.replace.title", "Replace in Project");
-    let keywordHint = AutoLispExt.localize("autolispext.project.findreplace.replace.hint.keyword", "Type a text string to find, and press Enter.");
+    let title = localize("autolispext.project.findreplace.replace.title", "Replace in Project");
+    let keywordHint = localize("autolispext.project.findreplace.replace.hint.keyword", "Type a text string to find, and press Enter.");
     let opt = await getSearchOption(title, keywordHint);
     if (opt.isKeywordProvided() == false)
         return;
 
-    let replacementHint = AutoLispExt.localize("autolispext.project.findreplace.replace.hint.replacement", "Type a text string to replace with, and press Enter.");
+    let replacementHint = localize("autolispext.project.findreplace.replace.hint.replacement", "Type a text string to replace with, and press Enter.");
     //get the replacment of given keyword
     let repl = await getString(title, replacementHint);
     if (repl == undefined)

--- a/extension/src/project/findReplace/searchTree.ts
+++ b/extension/src/project/findReplace/searchTree.ts
@@ -1,9 +1,11 @@
 import { DisplayNode, ProjectNode } from '../projectTree';
 import { IconUris } from '../icons';
 import { SearchOption } from './options';
-import * as vscode from 'vscode';
-import { AutoLispExt } from '../../extension';
 import {getTreeItemTitle } from '../projectutil'
+
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class FileNode implements DisplayNode {
     filePath: string = '';
@@ -102,31 +104,31 @@ export class SummaryNode implements DisplayNode {
         let prjNameClause = '';
         let prjPathStatement = '';
         if (prjNode) {
-            let inStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.in", " in ");
-            let prjFileStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.prjfile", "\r\nProject file: ");
+            let inStr = localize("autolispext.project.findreplace.searchtree.in", " in ");
+            let prjFileStr = localize("autolispext.project.findreplace.searchtree.prjfile", "\r\nProject file: ");
             prjNameClause = inStr + `${prjNode.projectName}`;
             prjPathStatement = prjFileStr + `${prjNode.projectFilePath}`;
         }
 
         if (opt.isReplace) {
-            let replace = AutoLispExt.localize("autolispext.project.findreplace.searchtree.replace", "Replace ");
-            let withStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.with", " with ");
+            let replace = localize("autolispext.project.findreplace.searchtree.replace", "Replace ");
+            let withStr = localize("autolispext.project.findreplace.searchtree.with", " with ");
             this.tooltip = replace + `\"${opt.keyword}\"` + withStr + `\"${opt.replacement}\"${prjNameClause};`;
         }
         else {
-            let findStr = AutoLispExt.localize("autolispext.project.findreplace.searchtree.find", "Find ");
+            let findStr = localize("autolispext.project.findreplace.searchtree.find", "Find ");
             this.tooltip = findStr + `\"${opt.keyword}\"${prjNameClause};`;
         }
         this.tooltip += prjPathStatement;
 
         if (opt.matchCase) {
-            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.matchcaseon", "\r\nMatch case: ON");
+            this.tooltip += localize("autolispext.project.findreplace.searchtree.matchcaseon", "\r\nMatch case: ON");
         }
         if (opt.matchWholeWord) {
-            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.matchwholewordon", "\r\nMatch whole word: ON");
+            this.tooltip += localize("autolispext.project.findreplace.searchtree.matchwholewordon", "\r\nMatch whole word: ON");
         }
         if (opt.useRegularExpr) {
-            this.tooltip += AutoLispExt.localize("autolispext.project.findreplace.searchtree.regexpon", "\r\nUse regular expression: ON");
+            this.tooltip += localize("autolispext.project.findreplace.searchtree.regexpon", "\r\nUse regular expression: ON");
         }
 
         this.tooltip += "\r\n" + this.summary;

--- a/extension/src/project/openLspFile.ts
+++ b/extension/src/project/openLspFile.ts
@@ -1,7 +1,9 @@
-import * as vscode from 'vscode';
-import { DisplayNode, LspFileNode, ProjectTreeProvider } from './projectTree';
-import { AutoLispExt } from '../extension';
-import * as fs from 'fs';
+import * as vscode from 'vscode'
+import { DisplayNode, LspFileNode, ProjectTreeProvider } from './projectTree'
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+const fs = require('fs')
 
 export async function openLspFile(clickedTreeItem: DisplayNode) {
 
@@ -17,7 +19,7 @@ export async function openLspFile(clickedTreeItem: DisplayNode) {
         }
 
         if (exists == false) {
-            let msg = AutoLispExt.localize("autolispext.project.openlspfile.filenotexist", "File doesn't exist: ");
+            let msg = localize("autolispext.project.openlspfile.filenotexist", "File doesn't exist: ");
             return Promise.reject(msg + lspNode.filePath);
         }
 

--- a/extension/src/project/openProject.ts
+++ b/extension/src/project/openProject.ts
@@ -1,12 +1,16 @@
-import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree';
+import { ProjectNode, LspFileNode, addLispFileNode2ProjectTree, isFileAlreadyInProject } from './projectTree'
 import { CursorPosition, ListReader } from '../format/listreader';
 import { Sexpression } from '../format/sexpression';
 import { ProjectDefinition } from './projectDefinition';
 import { CheckUnsavedChanges } from './checkUnsavedChanges';
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { ReadonlyDocument } from './readOnlyDocument';
 import { AutoLispExt } from '../extension';
+import * as vscode from 'vscode'
+import * as path from 'path'
+import { ReadonlyDocument } from './readOnlyDocument';
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+const fs = require('fs');
 import * as os from 'os';
 
 export async function OpenProject() {
@@ -21,7 +25,7 @@ export async function OpenProject() {
 
         let prjPathUpper = prjUri.fsPath.toUpperCase();
         if (prjPathUpper.endsWith(".PRJ") == false) {
-            let msg = AutoLispExt.localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
+            let msg = localize("autolispext.project.openproject.onlyprjallowed", "Only PRJ files are allowed.");
             return Promise.reject(msg);
         }
 
@@ -36,13 +40,13 @@ export async function OpenProject() {
 export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
     let document = ReadonlyDocument.open(prjUri.fsPath);
     if (!document) {
-        let msg = AutoLispExt.localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
+        let msg = localize("autolispext.project.openproject.readfailed", "Can't read project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
     let ret = ParseProjectDocument(prjUri.fsPath, document);
     if (!ret) {
-        let msg = AutoLispExt.localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
+        let msg = localize("autolispext.project.openproject.malformedfile", "Malformed project file: ");
         throw new Error(msg + prjUri.fsPath);
     }
 
@@ -50,7 +54,7 @@ export function OpenProjectFile(prjUri: vscode.Uri): ProjectNode {
 }
 
 async function SelectProjectFile() {
-    let label = AutoLispExt.localize("autolispext.project.openproject.label", "Open Project");
+    let label = localize("autolispext.project.openproject.label", "Open Project");
     const options: vscode.OpenDialogOptions = {
         //TBD: globalize
         canSelectMany: false,

--- a/extension/src/project/projectCommands.ts
+++ b/extension/src/project/projectCommands.ts
@@ -15,8 +15,11 @@ import { CheckUnsavedChanges } from './checkUnsavedChanges';
 import { clearSearchResults, clearSearchResultWithError, stopSearching, getWarnIsSearching } from './findReplace/clearResults';
 import { RefreshProject } from './refreshProject';
 import { AutoLispExt } from '../extension';
-import { grantExePermission } from './findReplace/ripGrep';
 import * as fs from 'fs-extra';
+
+import * as nls from 'vscode-nls';
+import { grantExePermission } from './findReplace/ripGrep';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerProjectCommands(context: vscode.ExtensionContext) {
     try {
@@ -41,7 +44,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(false);
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.createprojectfailed", "Failed to create the new project.");
+                let msg = localize("autolispext.project.commands.createprojectfailed", "Failed to create the new project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -58,16 +61,16 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                     ProjectTreeProvider.instance().updateData(prjNode);
                 })
                 .catch(err => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.openprojectfailed", "Failed to open the specified project.");
+                    let msg = localize("autolispext.project.commands.openprojectfailed", "Failed to open the specified project.");
                     showErrorMessage(msg, err);
                 });
         }));
 
         context.subscriptions.push(vscode.commands.registerCommand('autolisp.closeProject', async () => {
             if (ProjectTreeProvider.hasProjectOpened() === true){
-                let promptmsg = AutoLispExt.localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
-                let responseYes = AutoLispExt.localize("autolispext.project.commands.closepromptyes", "Yes");
-                let responseNo = AutoLispExt.localize("autolispext.project.commands.closepromptno", "No");
+                let promptmsg = localize("autolispext.project.commands.closepromptmsg", "Confirm close request on: ");
+                let responseYes = localize("autolispext.project.commands.closepromptyes", "Yes");
+                let responseNo = localize("autolispext.project.commands.closepromptno", "No");
                 vscode.window.showWarningMessage(promptmsg + ProjectTreeProvider.instance().projectNode.projectName, responseYes, responseNo).then(result => {
                     if (result === responseYes){
                         ProjectTreeProvider.instance().updateData(null);
@@ -86,7 +89,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                     return;//it's possible that the user cancelled the operation
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.addfilefailed", "Failed to add selected files to project.");
+                let msg = localize("autolispext.project.commands.addfilefailed", "Failed to add selected files to project.");
                 showErrorMessage(msg, err);
                 return;
             }
@@ -140,7 +143,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(true);
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -153,7 +156,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await excludeFromProject(selected);
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.removefilefailed", "Failed to remove selected file.");
+                let msg = localize("autolispext.project.commands.removefilefailed", "Failed to remove selected file.");
                 showErrorMessage(msg, err);
                 return;
             }
@@ -162,7 +165,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 await SaveProject(true);
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -173,11 +176,11 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
 
             SaveProject(true)
                 .then(prjPath => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.projectsaved", "Project file saved.");
+                    let msg = localize("autolispext.project.commands.projectsaved", "Project file saved.");
                     vscode.window.showInformationMessage(msg);
                 })
                 .catch(err => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
+                    let msg = localize("autolispext.project.commands.saveprojectfailed", "Failed to save the project.");
                     showErrorMessage(msg, err);
                 });
         }));
@@ -188,11 +191,11 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
 
             SaveAll()
                 .then(() => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.allsaved", "All files saved.");
+                    let msg = localize("autolispext.project.commands.allsaved", "All files saved.");
                     vscode.window.showInformationMessage(msg);
                 })
                 .catch(err => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.saveallfailed", "Failed to save all the files in the project.");
+                    let msg = localize("autolispext.project.commands.saveallfailed", "Failed to save all the files in the project.");
                     showErrorMessage(msg, err);
                 });
         }));
@@ -201,7 +204,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
             try {
                 RefreshProject();
             } catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.refreshfailed", "Failed to refresh the project.");
+                let msg = localize("autolispext.project.commands.refreshfailed", "Failed to refresh the project.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -209,7 +212,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.commands.registerCommand(ProjectTreeProvider.TreeItemClicked, (treeItem) => {
             openLspFile(treeItem)
                 .catch(err => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.openfilefailed", "Failed to open the file.");
+                    let msg = localize("autolispext.project.commands.openfilefailed", "Failed to open the file.");
                     showErrorMessage(msg, err);
                 })
         }));
@@ -220,7 +223,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 return;
 
             findInProject().catch(err => {
-                let msg = AutoLispExt.localize("autolispext.project.commands.findfailed", "Failed to find in project.");
+                let msg = localize("autolispext.project.commands.findfailed", "Failed to find in project.");
                 showErrorMessage(msg, err);
                 clearSearchResultWithError(msg + (err ? err.toString() : ''));
             });
@@ -232,7 +235,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 return;
 
             replaceInProject().catch(err => {
-                let msg = AutoLispExt.localize("autolispext.project.commands.replacefailed", "Failed to replace text string in project.");
+                let msg = localize("autolispext.project.commands.replacefailed", "Failed to replace text string in project.");
                 showErrorMessage(msg, err);
                 clearSearchResultWithError(msg + (err ? err.toString() : ''));
             })
@@ -241,7 +244,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.commands.registerCommand(SearchTreeProvider.showResult, (treeItem) => {
             openSearchResult(treeItem, SearchTreeProvider.instance.lastSearchOption)
                 .catch(err => {
-                    let msg = AutoLispExt.localize("autolispext.project.commands.openresultfailed", "Failed to open search results.");
+                    let msg = localize("autolispext.project.commands.openresultfailed", "Failed to open search results.");
                     showErrorMessage(msg, err);
                 })
         }));
@@ -254,7 +257,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
                 clearSearchResults();
             }
             catch (err) {
-                let msg = AutoLispExt.localize("autolispext.project.commands.clearresultfailed", "Failed to clear search results.");
+                let msg = localize("autolispext.project.commands.clearresultfailed", "Failed to clear search results.");
                 showErrorMessage(msg, err);
             }
         }));
@@ -274,7 +277,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
         grantExePermission();
     }
     catch (e) {
-        let msg = AutoLispExt.localize("autolispext.project.commands.initializefailed", "Failed to initalize the AutoLISP Project Manager.");
+        let msg = localize("autolispext.project.commands.initializefailed", "Failed to initalize the AutoLISP Project Manager.");
         vscode.window.showErrorMessage(msg);
         console.log(e);
     }

--- a/extension/src/project/projectDefinition.ts
+++ b/extension/src/project/projectDefinition.ts
@@ -1,4 +1,6 @@
 import { Sexpression } from '../format/sexpression';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class ProjectDefinition {
     static key_name: string = ":NAME";

--- a/extension/src/project/projectTree.ts
+++ b/extension/src/project/projectTree.ts
@@ -3,9 +3,11 @@ import { ProjectDefinition } from './projectDefinition';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { pathEqual } from '../utils';
-import { AutoLispExt } from '../extension';
-import * as fs from 'fs';
 import {getTreeItemTitle } from './projectutil'
+
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
+const fs = require('fs');
 
 export interface DisplayNode {
     getDisplayText: () => string;
@@ -31,7 +33,7 @@ export class ProjectNode implements DisplayNode {
 
     getDisplayText(): string {
         if (this.projectModified) {
-            let unsaved = AutoLispExt.localize("autolispext.project.tree.unsaved", " (UNSAVED)");
+            let unsaved = localize("autolispext.project.tree.unsaved", " (UNSAVED)");
             return this.projectName + unsaved;
         } else {
             return this.projectName;
@@ -73,7 +75,7 @@ export class LspFileNode implements DisplayNode {
         if (this.fileExists) {
             return this.filePath;
         } else {
-            let msg = AutoLispExt.localize("autolispext.project.tree.filenotexist", "File doesn't exist: ");
+            let msg = localize("autolispext.project.tree.filenotexist", "File doesn't exist: ");
             return msg + this.filePath;
         }
     }

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { AutoLispExt } from '../extension';
+import * as nls from 'vscode-nls';
 import { LispParser } from '../format/parser';
 import { LispAtom, Sexpression } from '../format/sexpression';
 import { DocumentManager } from '../documents';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export class ReadonlyLine implements vscode.TextLine {
     private constructor() {}
@@ -228,7 +229,7 @@ export class ReadonlyDocument implements vscode.TextDocument {
         }
 
         //the code shouldn't get here because it should have returned in the for loop when line == this.lineCount - 1
-        let msg = AutoLispExt.localize("autolispext.project.readonlydocument.convertoffsettopositionfailed", "Failed to convert offset to position.");
+        let msg = localize("autolispext.project.readonlydocument.convertoffsettopositionfailed", "Failed to convert offset to position.");
         throw new Error(msg);
     }
 

--- a/extension/src/project/saveProject.ts
+++ b/extension/src/project/saveProject.ts
@@ -1,18 +1,22 @@
 import { ProjectNode, ProjectTreeProvider } from './projectTree';
 import { ProjectDefinition } from './projectDefinition';
 import { LispFormatter } from '../format/formatter';
-import * as path from 'path';
+
+import * as path from 'path'
 import * as fs from 'fs-extra';
 import { pathEqual } from '../utils';
 import { ReadonlyDocument } from './readOnlyDocument';
-import { AutoLispExt } from '../extension';
-import {longListFormatAsSingleColum, resetLongListFormatAsSingleColum} from '../format/sexpression';
+import * as nls from 'vscode-nls';
+
+import {longListFormatAsSingleColum, resetLongListFormatAsSingleColum} from '../format/sexpression'
+
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 import * as vscode from 'vscode';
 
 export async function SaveProject(refresh: boolean) {
     try {
         if (ProjectTreeProvider.hasProjectOpened() == false) {
-            let msg = AutoLispExt.localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
+            let msg = localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
             return Promise.reject(msg);
         }
 
@@ -21,7 +25,7 @@ export async function SaveProject(refresh: boolean) {
         //work out the correct project file text
         let prjFileText = generateProjectText(root);
         if (!prjFileText) {
-            let msg = AutoLispExt.localize("autolispext.project.saveproject.generateprjcontentfailed", "Failed to generate project content.");
+            let msg = localize("autolispext.project.saveproject.generateprjcontentfailed", "Failed to generate project content.");
             return Promise.reject(msg);
         }
 
@@ -55,7 +59,7 @@ export async function SaveProject(refresh: boolean) {
 export async function SaveAll() {
     const root = ProjectTreeProvider.instance().projectNode;
     if (!root) {
-        let msg = AutoLispExt.localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
+        let msg = localize("autolispext.project.saveproject.noprojecttosave", "No project to save.");
         return Promise.reject(msg);
     }
 

--- a/extension/src/resources.ts
+++ b/extension/src/resources.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import { WebHelpLibrary } from "./help/openWebHelp";
-import * as fs from 'fs';
 
 
 export let internalLispFuncs: Array<string> = [];
@@ -30,6 +29,7 @@ export interface IJsonLoadable {
 
 
 function readJsonDataFile(datafile: string, intoObject: IJsonLoadable): void {
+	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {        
 		if (err === null && intoObject["loadFromJsonObject"]) {
@@ -40,6 +40,7 @@ function readJsonDataFile(datafile: string, intoObject: IJsonLoadable): void {
 
 
 function readDataFileByLine(datafile: string, action: (items: string[]) => void) {
+	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {
 		if (err === null) {
@@ -55,6 +56,7 @@ function readDataFileByLine(datafile: string, action: (items: string[]) => void)
 
 
 function readDataFileByDelimiter(datafile: string, delimiter: string, action: (item: string) => void) {
+	var fs = require("fs");
 	var dataPath = path.resolve(__dirname, datafile);
 	fs.readFile(dataPath, "utf8", function(err: Error, data: string) {
 		var lineList = new Array<String>();

--- a/extension/src/statusbar.ts
+++ b/extension/src/statusbar.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 import { isSupportedLispFile } from './platform';
 import * as os from 'os';
-import { AutoLispExt } from './extension';
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function registerLoadLispButton(context: vscode.ExtensionContext) {
 	let lspLoadButton = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-	let title = AutoLispExt.localize("autolispext.loadlisp.title", "Load lisp");
+	let title = localize("autolispext.loadlisp.title", "Load lisp");
 	lspLoadButton.text = "📄" + title;
 	lspLoadButton.color = 'white';
-	lspLoadButton.tooltip = AutoLispExt.localize("autolispext.loadlisp.tooltip", "Load the Current File");
+	lspLoadButton.tooltip = localize("autolispext.loadlisp.tooltip", "Load the Current File");
 	lspLoadButton.command = "autolisp.loadActiveFile";
 	lspLoadButton.show();
 	context.subscriptions.push(vscode.commands.registerCommand("autolisp.loadActiveFile", () => {
@@ -18,17 +19,17 @@ export function registerLoadLispButton(context: vscode.ExtensionContext) {
 			if (vscode.debug.activeDebugSession !== undefined) {
 				vscode.debug.activeDebugSession.customRequest("customLoad", currentLSPDoc);
 			} else {
-				const message = AutoLispExt.localize("autolispext.loadlisp.attach", "First, attach to or launch a host application before loading this file.");
+				const message = localize("autolispext.loadlisp.attach", "First, attach to or launch a host application before loading this file.");
 				vscode.window.showErrorMessage(message);
 			}
 		} else {
 			let platform = os.type();
 			if(platform === 'Windows_NT'){
-				const message = AutoLispExt.localize("autolispext.loadlisp.fileformat.win", "This file format isn’t supported. Activate a window containing a DCL, LSP, or MNL file.");
+				const message = localize("autolispext.loadlisp.fileformat.win", "This file format isn’t supported. Activate a window containing a DCL, LSP, or MNL file.");
 				vscode.window.showErrorMessage(message);
 			}
 			else{
-				const message = AutoLispExt.localize("autolispext.loadlisp.fileformat.mac", "This file format isn’t supported. Activate a window containing a DCL or LSP file.");
+				const message = localize("autolispext.loadlisp.fileformat.mac", "This file format isn’t supported. Activate a window containing a DCL or LSP file.");
 				vscode.window.showErrorMessage(message);
 			}	
 		}

--- a/extension/src/uriHandler.ts
+++ b/extension/src/uriHandler.ts
@@ -2,9 +2,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { activeDocHasValidLanguageId } from './utils';
-import { setDefaultAcadPid } from "./debug";
-import { AutoLispExt } from './extension';
+
+import {
+    acitiveDocHasValidLanguageId
+} from './utils'
+import { setDefaultAcadPid } from "./debug"
+import * as nls from 'vscode-nls';
+const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
 function getUrlParams(queryString) {
     let hashes = queryString.split('&')
@@ -20,7 +24,7 @@ export function onUriRequested(uri: vscode.Uri) {
 
     let pidStr = qs["pid"];
     if (pidStr === undefined) {
-        let msg = AutoLispExt.localize("autolispext.urihandler.invaid", "Invalid call to AutoCAD AutoLISP Extension.");
+        let msg = localize("autolispext.urihandler.invaid", "Invalid call to AutoCAD AutoLISP Extension.");
         vscode.window.showInformationMessage(msg);
         return;
     }
@@ -28,20 +32,20 @@ export function onUriRequested(uri: vscode.Uri) {
     setDefaultAcadPid(parseInt(pidStr));
 
     if (vscode.debug.activeDebugSession) {
-        let msg = AutoLispExt.localize("autolispext.urihandler.activeddebugcfg", "Current debug configuration: ");
+        let msg = localize("autolispext.urihandler.activeddebugcfg", "Current debug configuration: ");
         vscode.window.showInformationMessage(msg + vscode.debug.activeDebugSession.name,
             modalMsgOption);
         return;
     }
 
     if (vscode.window.activeTextEditor) {
-        if (activeDocHasValidLanguageId()) {
-            let msg = AutoLispExt.localize("autolispext.urihandler.debug.start",
+        if (acitiveDocHasValidLanguageId()) {
+            let msg = localize("autolispext.urihandler.debug.start",
                 "From the menu bar, click Run > Start Debugging to debug the current AutoLISP source file.");
             vscode.window.showInformationMessage(msg, modalMsgOption);
         }
         else {
-            let msg = AutoLispExt.localize("autolispext.urihandler.debug.openfile",
+            let msg = localize("autolispext.urihandler.debug.openfile",
                 "Open an AutoLISP source file and click Run > Start Debugging from the menu bar to debug the file.");
             vscode.window.showInformationMessage(msg, modalMsgOption);
         }
@@ -49,7 +53,7 @@ export function onUriRequested(uri: vscode.Uri) {
         return;
     }
 
-    let msg = AutoLispExt.localize("autolispext.urihandler.debug.openfile",
+    let msg = localize("autolispext.urihandler.debug.openfile",
         "Open an AutoLISP source file and click Run > Start Debugging from the menu bar to debug the file.");
     vscode.window.showInformationMessage(msg, modalMsgOption);
 

--- a/extension/src/utils.ts
+++ b/extension/src/utils.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import * as path from 'path';
+import * as path from 'path'
 import * as fs from 'fs-extra';
-import * as os from 'os';
+
+const os = require('os');
 
 export function getFullDocRange(editor: vscode.TextEditor): vscode.Range {
     return editor.document.validateRange(
@@ -24,7 +25,7 @@ export function getSelectedDocRange(editor: vscode.TextEditor): vscode.Range {
     );
 }
 
-export function activeDocHasValidLanguageId(): Boolean {
+export function acitiveDocHasValidLanguageId(): Boolean {
     const editor = vscode.window.activeTextEditor;
 
     return editor.document.languageId === 'autolisp' ||

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "autolispext",
 	"displayName": "AutoCAD AutoLISP Extension",
 	"description": "This is a vscode extension for AutoCAD AutoLISP",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"bugs": {
 		"url": "https://github.com/Autodesk-AutoCAD/AutoLispExt/issues"


### PR DESCRIPTION
##### Objective
I want to fix the regression introduced by this commit: https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/37
It breaks all the localization strings in TS files.

##### Abstractions
For vscode extension localization we referenced the vscode sample project like https://github.com/microsoft/vscode-extension-samples/blob/master/i18n-sample/src/extension.ts#L8
And it uses the `GULP` library to inject and load the resource json files. So for each TS files it has codes like:
```
import * as nls from 'vscode-nls';
const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
```
This does ALL the good stuff, it inject lots of javascript codes in the background, let the gulp to load the "correct" json files when loading.

But in the PR https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/37 we move the codes to context.ts file, so gulp only take cares the gulp.json, it will not search and load the other TS file's resource string.

##### Tests performed
 - passed build
 -  try to verify some features in the Chinese display language setting

##### Screen shot
![image](https://user-images.githubusercontent.com/68938334/106983474-ec311500-67a0-11eb-87e2-33fb5eee26b7.png)
