### PR TITLE
Analytical Parser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
             "name": "Extension Client",
             "type": "extensionHost",
             "request": "launch",
+            "preLaunchTask": "buildproject",
             "runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/extension/out/**/*.js"],
@@ -18,6 +19,7 @@
             "name": "Extension Tests",
             "type": "extensionHost",
             "request": "launch",
+            "preLaunchTask": "buildproject",
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
+			"label": "buildproject",
 			"type": "npm",
 			"script": "compile",
 			"group": "build",

--- a/extension/src/format/parser.ts
+++ b/extension/src/format/parser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ListReader, CursorPosition } from "./listreader";
-import { Sexpression } from "./sexpression";
+import { LispAtom, Sexpression } from "./sexpression";
 
 class LeftParentItem {
     public location: Number;
@@ -181,5 +181,175 @@ export class LispParser {
             let lispLists = reader.tokenize();
             this.atomsForest.push(lispLists);
         }
+    }
+}
+
+
+
+
+export namespace LispParser {
+    
+    enum ParseState {
+        UNKNOWN = 0,
+        STRING = 1,
+        COMMENT = 2
+    }
+
+    interface CountTracker {
+        idx: number;
+        line: number;
+        column: number;
+        linefeed: string;
+    }
+
+    export function getDocumentSexpression(data: string|vscode.TextDocument, offset?: number|vscode.Position, tracker?: CountTracker): Sexpression {
+        let documentText = '';
+        if (data instanceof Object) {
+            documentText = data.getText();
+        } else {
+            documentText = data;
+        }
+        if (!offset) {
+            offset = 0;
+        }
+        if (!tracker){
+            tracker = {
+                idx: 0, line: 0, column: 0, 
+                linefeed: data instanceof Object ? LispParser.getEOL(data) : (data.indexOf('\r\n') >= 0 ? '\r\n' : '\n')
+            };
+        }
+        
+        const result = new Sexpression();
+        result.line = tracker.line;
+        result.column = tracker.column;
+        result.linefeed = tracker.linefeed;
+        
+        let isAuthorized = true;
+        let state = ParseState.UNKNOWN;
+        let grpStart: vscode.Position = null;
+        let temp = '';
+        
+        while (tracker.idx < documentText.length && isAuthorized) {
+            const curr = documentText[tracker.idx];
+            const next = documentText[tracker.idx + 1];
+            
+            let doWork = false;
+            if (offset instanceof vscode.Position) {
+                doWork = tracker.line >= offset.line && tracker.column >= offset.character;
+            } else {
+                doWork = tracker.idx >= offset;
+            }
+
+            if (doWork === false) {
+                if (curr === '\n'){
+                    tracker.line++;
+                    tracker.column = -1;
+                }
+                tracker.idx++;
+                tracker.column++;
+            } else {
+                let handled = false; // Only true when this function gets recursively called because of a new open parenthesis (Sexpression) scope
+                switch (state) {
+                    case ParseState.UNKNOWN:                    
+                        if (grpStart === null && curr === '\'' && next === '(') {
+                            result.atoms.push(new LispAtom(tracker.line, tracker.column, curr));
+                        } else if (grpStart === null && curr === '(') {
+                            grpStart = new vscode.Position(tracker.line, tracker.column);
+                            result.atoms.push(new LispAtom(grpStart.line, grpStart.character, curr));
+                        } else if (curr === ')') {
+                            if (temp.length > 0) {                            
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                            }
+                            temp = '';
+                            result.atoms.push(new LispAtom(tracker.line, tracker.column, curr));
+                            grpStart = null;
+                            isAuthorized = false;
+                        } else if (curr === '(' || curr === '\'' && next === '(') {
+                            if (temp.length > 0) {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));                            
+                            }
+                            temp = '';
+                            result.atoms.push(getDocumentSexpression(documentText, offset, tracker));
+                            handled = true;
+                        } else if (curr === ';') {
+                            if (temp.length > 0) {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                            }
+                            temp = ';';
+                            grpStart = new vscode.Position(tracker.line, tracker.column);
+                            state = ParseState.COMMENT;
+                        } else if (curr === '"') {
+                            if (temp.length > 0) {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                            }
+                            temp = '"';
+                            grpStart = new vscode.Position(tracker.line, tracker.column);
+                            state = ParseState.STRING;
+                        } else if (/\s/.test(curr)) {
+                            if (temp.length > 0) {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                            }
+                            if (curr === '\n'){
+                                tracker.line++;
+                                tracker.column = -1;
+                            }
+                            temp = '';
+                        } else { // This is some other kind of readable character, so it can start a group pointer
+                            if (temp === '') { 
+                                grpStart = new vscode.Position(tracker.line, tracker.column);
+                            }
+                            temp += curr;
+                        }
+                        break;
+                    case ParseState.STRING:
+                        temp += curr;
+                        // these 2 endswith tests are hard to understand, but they were vetted on a previous C# lisp parser to detect escaped double quotes
+                        if (curr === '"' && (temp.endsWith("\\\\\"") || !temp.endsWith("\\\""))) {    
+                            result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                            state = ParseState.UNKNOWN;
+                            temp = '';
+                        } 
+                        if (curr === '\n'){
+                            tracker.line++;
+                            tracker.column = -1;
+                        }
+                        break;
+                    case ParseState.COMMENT:                    
+                        if (temp[1] === '|') {
+                            temp += curr;
+                            if (temp.endsWith('|;')) {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                                state = ParseState.UNKNOWN;
+                                temp = '';
+                            }
+                            if (curr === '\n'){
+                                tracker.line++;
+                                tracker.column = -1;
+                            }
+                        } else {
+                            if (curr === '\r' || curr === '\n') {
+                                result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+                                state = ParseState.UNKNOWN;
+                                temp = '';
+                            } else {
+                                temp += curr;
+                            }
+                        }
+                        break;
+                }
+                if (handled === false) {
+                    tracker.idx++;                
+                    tracker.column++;
+                }
+            }
+        }
+        if (temp.length > 0) {
+            result.atoms.push(new LispAtom(grpStart.line, grpStart.character, temp));
+        }
+        if (result.atoms.length > 0) {
+            result.line = result.atoms[0].line;
+            result.column = result.atoms[0].column;
+        }
+        return result;
     }
 }

--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -916,7 +916,7 @@ export class Sexpression extends LispAtom {
     getRange(){
         const begin: LispAtom = this.atoms[0];
         const close: LispAtom = this.atoms[this.atoms.length -1];
-        return new Range(begin.line, begin.column, close.line, (close.column + close.symbol.length) - 1);
+        return new Range(begin.line, begin.column, close.line, (close.column + close.symbol.length));
     }
 
     

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -106,13 +106,13 @@ export class ReadonlyDocument implements vscode.TextDocument {
 
     
     // Converted this from a constant data feature into an on-demand feature that once used is essentially cached for future queries.
-    get atomsForest(): Array<string|Sexpression> {
+    get atomsForest(): Array<LispAtom|Sexpression> {
         if (this.languageId === DocumentManager.Selectors.lsp) {
-            if (this._atomsForest){
-                return this._atomsForest;
+            if (this._docExpression){
+                return this._docExpression.atoms;
             } else {
                 this.updateAtomsForest();
-                return this._atomsForest;
+                return this._docExpression.atoms;
             }
         } else {
             return [];
@@ -127,20 +127,14 @@ export class ReadonlyDocument implements vscode.TextDocument {
             if (content) {
                 this.initialize(content, this.languageId);
             }
-            let parser = new LispParser(this);
-            try {
-                parser.tokenizeString(this.fileContent, 0);        
-                this._atomsForest = [...parser.atomsForest];    
-            } finally {
-                parser = undefined;
-            }
+            this._docExpression = LispParser.getDocumentSexpression(this.fileContent);  
         }
     }
 
     fileContent: string;
     lines: string[];
     eolLength: number;
-    private _atomsForest: Array<string|Sexpression>; // Added to drastically reduces complexity in other places.
+    private _docExpression: Sexpression; // Added to drastically reduces complexity in other places.
 
     //#region implementing vscode.TextDocument
 

--- a/extension/src/test/suite/DocumentExpression.test.ts
+++ b/extension/src/test/suite/DocumentExpression.test.ts
@@ -1,0 +1,105 @@
+import { debug } from 'console';
+import * as path from 'path';
+import { debuglog } from 'util';
+import { Position, Range } from 'vscode';
+import { LispParser } from '../../format/parser';
+import { Sexpression } from '../../format/sexpression';
+import { ReadonlyDocument } from '../../project/readOnlyDocument';
+
+
+var assert = require('chai').assert;
+let project_path = path.join(__dirname + "\\..\\..\\..\\test_case\\pdfMarkups.lsp");
+
+
+suite("LispParser.DocumentExpression Tests", function () {	
+	test("Original atomsForest vs DocumentSexpression", function () {	
+		try {
+			const doc = ReadonlyDocument.open(project_path); 						
+			const v1Start = Date.now();
+			const v1items = doc.atomsForest.filter(x => x instanceof Sexpression);
+			const v1Stop = Date.now();
+			const dex = LispParser.getDocumentSexpression(doc.fileContent);			
+			const v2items = dex.atoms.filter(x => x instanceof Sexpression);
+			const v2Stop = Date.now();			
+			const v1Diff = v1Stop - v1Start;
+			const v2Diff = v2Stop - v1Stop;		
+			assert.isTrue(v2Diff <= v1Diff || v1Diff - v2Diff <= 2);
+			assert.equal(v2items.length, v1items.length);
+		}
+		catch (err) {
+			assert.fail("Each version returned a different number of Sexpressions");
+		}
+	});
+
+
+	test("DocumentSexpression using index", function () {		
+		try {
+			const expectation = '(= (length retList) 1)';
+			const doc = ReadonlyDocument.open(project_path); 						
+			// tried testing the tolkenize version, but it doesn't actually work for me. Gets stuck in an infinite loop.
+				// const v1Start = Date.now();
+				// const p = new LispParser(doc);
+				// p.tokenizeString(doc.getText(), 310);
+				// const v1items = p.atomsForest.filter(x => x instanceof Sexpression);
+			const v1Stop = Date.now();
+			const iex = LispParser.getDocumentSexpression(doc.getText(), 6847);
+			const v2items = iex.atoms.filter(x => x instanceof Sexpression);
+			const v2Stop = Date.now();									
+
+				// const v1Diff = v1Stop - v1Start;
+			const v2Diff = v2Stop - v1Stop;
+				//assert.isTrue(v2Diff <= v1Diff);
+				// assert.equal(v2items.length, v1items.length);
+
+				// can't currently use the Sexpression getRange because there are ending character differences between my implementation and the atoms forest that need to be worked out.
+			const r = new Range(iex.line, iex.column, iex.atoms.slice(-1)[0].line, iex.atoms.slice(-1)[0].column + 1);
+			assert.equal(doc.getText(r), expectation);
+		}
+		catch (err) {
+			assert.fail("Each version returned a different number of Sexpressions");
+		}
+	});
+
+	test("DocumentSexpression using vscode.Position", function () {		
+		try {
+			const expectation = '(= (length retList) 1)';
+			const doc = ReadonlyDocument.open(project_path);
+			const v1Stop = Date.now();
+			const pex = LispParser.getDocumentSexpression(doc, new Position(151,29));
+			const v2Stop = Date.now();
+			const v2Diff = v2Stop - v1Stop;
+			// can't currently use the Sexpression getRange because there are ending character differences between my implementation and the atoms forest that need to be worked out.
+			const r = new Range(pex.line, pex.column, pex.atoms.slice(-1)[0].line, pex.atoms.slice(-1)[0].column + 1);
+			assert.equal(doc.getText(r), expectation);
+		}
+		catch (err) {
+			assert.fail("Each version returned a different number of Sexpressions");
+		}
+	});
+
+
+	test("String Source: Test Unix EOLs", function () {
+		try { 
+			const val = '(defun C:DoStuff (/ pt)\n\t(setq pt (getpoint))\n\t(command ".point" pt)\n\t)';
+			const dex = LispParser.getDocumentSexpression(val, 0);
+			assert.equal(dex.atoms.length, 7);
+			assert.equal(dex.linefeed, '\n');
+		}
+		catch (err) {
+			assert.fail("Incorrect parse quantity or EOL value");
+		}
+	});
+
+	test("String Source: Test Windows EOLs", function () {
+		try { 
+			const val = '(defun C:DoStuff (/ pt)\r\n\t(setq pt (getpoint))\r\n\t(command ".point" pt)\r\n\t)';
+			const dex = LispParser.getDocumentSexpression(val, 0);
+			assert.equal(dex.atoms.length, 7);
+			assert.equal(dex.linefeed, '\r\n');
+		}
+		catch (err) {
+			assert.fail("Incorrect parse quantity or EOL value");
+		}
+	});
+
+});

--- a/extension/src/test/suite/Sexpression.test.ts
+++ b/extension/src/test/suite/Sexpression.test.ts
@@ -27,7 +27,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 				test("Sexpression.getRange()", function () {
 					try {
 						const txt = doc.getText(exp.getRange());									
-						assert.equal(txt.length, 6033);
+						assert.closeTo(txt.length, 6033, 1);
 					}
 					catch (err) {
 						assert.fail("Invalid range from Sexpression");
@@ -49,7 +49,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 					try {
 						const sexp = exp.getSexpressionFromPos(pos);
 						const txt = doc.getText(sexp.getRange());
-						assert.equal(txt.length, 71);
+						assert.closeTo(txt.length, 71, 1);
 					}
 					catch (err) {
 						assert.fail("Invalid quantity, has the LSP changed?");
@@ -62,7 +62,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 						const par1 = exp.getParentOfSexpression(sexp);
 						const par2 = exp.getParentOfSexpression(par1);
 						const txt = doc.getText(par2.getRange());
-						assert.equal(txt.length, 99);
+						assert.closeTo(txt.length, 99, 1);
 					}
 					catch (err) {
 						assert.fail("Invalid quantity, has the LSP changed?");

--- a/extension/src/test/suite/Sexpression.test.ts
+++ b/extension/src/test/suite/Sexpression.test.ts
@@ -27,7 +27,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 				test("Sexpression.getRange()", function () {
 					try {
 						const txt = doc.getText(exp.getRange());									
-						assert.closeTo(txt.length, 6033, 1);
+						assert.equal(txt.length, 6033);
 					}
 					catch (err) {
 						assert.fail("Invalid range from Sexpression");
@@ -49,7 +49,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 					try {
 						const sexp = exp.getSexpressionFromPos(pos);
 						const txt = doc.getText(sexp.getRange());
-						assert.closeTo(txt.length, 71, 1);
+						assert.equal(txt.length, 71);
 					}
 					catch (err) {
 						assert.fail("Invalid quantity, has the LSP changed?");
@@ -62,7 +62,7 @@ suite("ReadonlyDocument.findExpressions() Tests", function () {
 						const par1 = exp.getParentOfSexpression(sexp);
 						const par2 = exp.getParentOfSexpression(par1);
 						const txt = doc.getText(par2.getRange());
-						assert.closeTo(txt.length, 99, 1);
+						assert.equal(txt.length, 99);
 					}
 					catch (err) {
 						assert.fail("Invalid quantity, has the LSP changed?");


### PR DESCRIPTION
**Objective**
It was discovered that the existing AtomsForest in the LispParser has an exponential performance problem. On really large documents (8000 lines) this was taking a very substantial amount of time to generate. This PR intends to replace that functionality for (at least) new features suffering from those discovered performance impacts. The existing Parser will continue to be used for its original purpose (formatting) since it is dependent on knowledge of white space and this has a focus on concrete Atoms & Sexpressions.

I tweaked the launch.json & tasks.json files to compile the TS from F5 so I didn't have to keep running other scripts as a secondary step. From a fresh clone you would still need to use the pack.py to get the file dependencies copied.

**Abstraction**
The `getDocumentSexpression()` function was tacked onto the existing LispParser object namespace to isolate it from the existing code base and was designed to parse the contents of a document or string into an Sexpression. 

**Implementation**
This takes a much more linear approach of reducing document content into LispAtom & Sexpression segments. It does this by parsing the current level LispAtoms and then recursively calling itself to generate child Sexpressions. While persisting its index/line tracking mechanism object into those recursive calls.

**Tests Performed**
New tests *.TS was added to the test suite. I also took a massive (3500 line) document, filtered out the Sexpressions from both the OLD/NEW parsers and compared the results for anomalies. Which generated the **Quirks** section below. Mild alteration to the `ReadOnlyDocument` object to house a document wide Sexpression and to change the `AtomsForest` property to `Array<LispAtom|Sexpression>`. This effectively hooked up F12 to this new data model.

**Additional Information**
While doing this and comparing the output to the existing atomsForest, a few **Quirks** were discovered in the original versions column # values. 

**Quirks**
Note: In all situations, except where stated below, the column index is equal to the start of a LispAtom or Sexpression.
- Quote Marks Prefixing a Parenthesis
  - Old Version
    - The Sexpression Parent, Quote & the Parenthesis all have the same column index. Which all literally represent the location of the parenthesis within the document.
  - New Version
    - The Sexpression Parent & Quote have the same column index and literally represent their location within the document. The parenthesis also has a column index that literally represent its own location in the document.

- Closing Parenthesis
  - Old Version
    - The closing parenthesis LispAtom column index represents the true end of the Sexpression.
  - New Version
    - The closing parenthesis LispAtom column index represents the start of that LispAtom.
      - Note, Sexpression.getRange() was updated to function with the new version. Nothing in the "formatting parser" model was using this and instead made range specific calculations manually. It should be safe to consider the `Sexpression.getRange()` part of the "analytical parser" model that does not intend to do anything like that manually, but rather lean on providers such as getRange.