### PR TITLE
Scan only out folder for codeql

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,10 +1,13 @@
 name: "Custom CodeQL Config"
 
 queries:
-- uses: security-and-quality
+  - uses: security-and-quality
 
 paths:
-- 'AutoLispExt/**/out/**/*.js'
+  - 'AutoLispExt/**/out/**/*.js'
 
 paths-ignore:
-- '**/.vscode-test/**'
+  - '**/.vscode-test/**'
+  - '**/*.md'
+  - '**/*.txt'
+  

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,7 +4,7 @@ queries:
 - uses: security-and-quality
 
 paths:
-- '**/out/**'
+- '**/AutoLispExt/**/out/**/*.js'
 
 paths-ignore:
 - '**/.vscode-test/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,7 +4,7 @@ queries:
 - uses: security-and-quality
 
 paths:
-- '**/AutoLispExt/**/out/**/*.js'
+- 'AutoLispExt/**/out/**/*.js'
 
 paths-ignore:
 - '**/.vscode-test/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,7 +4,7 @@ queries:
 - uses: security-and-quality
 
 paths:
-- '**/extension/src/**'
+- '**/out/**'
 
 paths-ignore:
 - '**/.vscode-test/**'

--- a/DevREADME.md
+++ b/DevREADME.md
@@ -41,6 +41,16 @@ You have two ways to run the tests:
 npm run test
 ```
 
+## Run test code coverage
+
+You have two ways to run the tests:
+
+  - Run on terminal outside of VS Code and make sure no VS code is running (VS Code terminal will not work due to VS Code limitation) 
+  - Run within vscode insider version
+```
+npm run cc
+```
+
 ### localization notices
 It uses the gulp to do localization to reference project https://github.com/microsoft/vscode-extension-samples/tree/master/i18n-sample
 And the codes in each ts file:


### PR DESCRIPTION
##### Objective
Specify only /out/ folder to do the codeql since I found it takes too long time for codeql on Github CI.

##### Abstractions
<!-- How to do the changes, or the algorithm -->

##### Tests performed


##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
