### PR TITLE
Added MochAwesome & a Launch Config to open reports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,22 @@
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ]
-        }
+        },
+        {
+            "name": "Extension Tests + Reporting",
+            "type": "extensionHost",
+            "request": "launch",
+            "preLaunchTask": "buildproject",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/suite/codeCoverage"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "postDebugTask": "OpenCoverageTestReport"
+        },
     ],
     "compounds": [
 		{

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,17 @@
 			"problemMatcher": [
 				"$tsc-watch"
 			]
-        }
+        },
+		{
+			"label": "OpenCoverageTestReport",
+			"type": "shell",
+			"command": "./coverage/index.html",
+			"dependsOn": "OpenMochawesomeTestReport"
+		},
+		{
+			"label": "OpenMochawesomeTestReport",
+			"type": "shell",
+			"command": "./coverage/mochawesome/mochawesome.html"
+		}
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,14 +33,16 @@
         },
 		{
 			"label": "OpenCoverageTestReport",
-			"type": "shell",
-			"command": "./coverage/index.html",
+			"type": "shell",			
+			"windows": {"command": "./coverage/index.html"},
+			"osx": {"command": "open ./coverage/index.html"},
 			"dependsOn": "OpenMochawesomeTestReport"
 		},
 		{
 			"label": "OpenMochawesomeTestReport",
 			"type": "shell",
-			"command": "./coverage/mochawesome/mochawesome.html"
+			"windows": {"command": "./coverage/mochawesome/mochawesome.html"},
+			"osx": {"command": "open ./coverage/mochawesome/mochawesome.html"}
 		}
     ]
 }

--- a/extension/src/test/suite/codeCoverage.ts
+++ b/extension/src/test/suite/codeCoverage.ts
@@ -13,7 +13,11 @@ const NYC = require('nyc');
 export async function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
-		ui: 'tdd'
+		ui: 'tdd',
+		reporter: 'mochawesome',
+		reporterOptions: {
+			'reportDir': path.resolve(__dirname, '../../../coverage/mochawesome')
+		}
 	});
 	mocha.useColors(true);
 

--- a/package.json
+++ b/package.json
@@ -634,11 +634,12 @@
 		"gulp-sourcemaps": "^2.6.5",
 		"gulp-typescript": "^5.0.1",
 		"mocha": "^6.1.4",
+		"mochawesome": "^6.2.2",
 		"nyc": "^15.1.0",
 		"run-sequence": "^2.2.1",
 		"source-map-resolve": "0.6.0",
-		"tslint": "5.11.0",
 		"ts-node": "^9.1.1",
+		"tslint": "5.11.0",
 		"typescript": "^3.9.7",
 		"vscode-nls-dev": "^3.2.6",
 		"vscode-test": "^1.4.1"


### PR DESCRIPTION
##### Objective
Looks like the project objectives are getting our testing up to date. I would like to add to the fine work you've been doing. This PR includes Mochawesome HTML Test Reporting and a launch configuration to utilize the Test/Coverage reports. Note that I did not submit any update to the package-lock.json simply because I thought it could add complexity to all the various things you have in progress.

##### Tests performed
The new launch configuration was tested on a Windows machine. I honestly don't know if the generic tasks to launch the html files will work on a Mac or Linux boxes. I did try testing on a Mac, but I haven't owned a Mac for very long and don't know what "failed to read string on top level" means; neither did google... Either way, that is happening long before it even runs tests so it is unrelated. 
