### PR TITLE
Fix test failure on Mac about end-of-line

### DIFF
--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -87,19 +87,19 @@ export class ReadonlyDocument implements vscode.TextDocument {
         return ret;
     }
 
-    initialize(fileContent: string, languageId: string) {
-        this.fileContent = fileContent.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
+    initialize(contentOfFile: string, langId: string) {
+        this.fileContent = contentOfFile.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
         this.eol = vscode.EndOfLine.CRLF;
         this.eolLength = 2;
 
-        this.languageId = languageId;
+        this.languageId = langId;
 
         if (this.fileContent.length === 0) {
             this.lineCount = 0;
             this.lines = [];
         }
         else {
-            this.lines = fileContent.split('\r\n');
+            this.lines = this.fileContent.split('\r\n');
             this.lineCount = this.lines.length;
         }
     }

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -88,7 +88,7 @@ export class ReadonlyDocument implements vscode.TextDocument {
     }
 
     initialize(rawContent: string, langId: string) {
-        this.fileContent = rawContent.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
+        this.fileContent = rawContent.replace(/\r*\n/g, '\r\n');//rawContent.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
         this.eol = vscode.EndOfLine.CRLF;
         this.eolLength = 2;
 

--- a/extension/src/project/readOnlyDocument.ts
+++ b/extension/src/project/readOnlyDocument.ts
@@ -87,8 +87,8 @@ export class ReadonlyDocument implements vscode.TextDocument {
         return ret;
     }
 
-    initialize(contentOfFile: string, langId: string) {
-        this.fileContent = contentOfFile.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
+    initialize(rawContent: string, langId: string) {
+        this.fileContent = rawContent.split('\r\n').join('\n').split('\n').join('\r\n');//to make sure every line ends with \r\n
         this.eol = vscode.EndOfLine.CRLF;
         this.eolLength = 2;
 

--- a/extension/src/test/suite/codeCoverage.ts
+++ b/extension/src/test/suite/codeCoverage.ts
@@ -50,7 +50,7 @@ async function setupNYC() {
 	});
 	await nyc.wrap();
 
-	// Delete the 'coverage' folder first to make sure the HTML report is only for current run of npm test
+	// To make sure the report is only for current run
 	const tempDirectory = nyc.tempDirectory();
 	if(fs.existsSync(tempDirectory)) {
 		fs.removeSync(tempDirectory);


### PR DESCRIPTION
##### Objective
A potential bug is discovered by running automation tests on Mac. Error "failed to read string on top level" is printed in console.

##### Abstractions
It's caused by an error in a line of code. Unlike Windows, when running tests on Mac, the calls to split and join methods (which was added for an edge case, and not needed with the given test data) will change the original string, and this is why the error is discovered. On Windows, the original string is untouched, and that original string is already in correct format, so the test case passes.

##### Tests performed
Tested on Mac. The error is gone. All 40 tests pass.

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
