### PR TITLE
Add 2 E2E tests to verify the 'debug' and 'launch' modes are correctly configured

### DIFF
--- a/extension/src/test/e2e/debugConfig.ts
+++ b/extension/src/test/e2e/debugConfig.ts
@@ -72,8 +72,8 @@ describe('Debug Configuration Test', () => {
 
     debugStarted = true;
 
-    const procInput = await getActiveInputBox();
-    expect((await procInput.getPlaceHolder()).startsWith(expectedLaunchHint)).true;
+    const pathInput = await getActiveInputBox();
+    expect((await pathInput.getPlaceHolder()).startsWith(expectedLaunchHint)).true;
   });
 
   async function findAll(array, callbackFind): Promise<Array<InputBox>> {

--- a/extension/src/test/e2e/debugConfig.ts
+++ b/extension/src/test/e2e/debugConfig.ts
@@ -2,50 +2,99 @@ import { expect } from 'chai';
 import { InputBox, Workbench } from 'vscode-extension-tester';
 
 describe('Debug Configuration Test', () => {
-  let input: InputBox;
+  let workbench: Workbench = null;
+  let activeInput: InputBox = null;
+  let debugStarted: boolean = false;
 
-  const attachConfigText:string = 'AutoLISP Debug: Attach';
-  const launchConfigText:string = 'AutoLISP Debug: Launch';
-  const startDebugCmd:string = 'workbench.action.debug.start';
-  
-  before(async () => {
+  const attachConfigText: string = 'AutoLISP Debug: Attach';
+  const launchConfigText: string = 'AutoLISP Debug: Launch';
+
+  const startDebugCmd: string = 'workbench.action.debug.start';
+  const stopDebugCmd: string = 'workbench.action.debug.stop';
+
+  const expectedAttachHint = 'Pick the process to attach.';
+  const expectedLaunchHint = 'Specify the absolute path for the product.';
+
+  beforeEach(async () => {
+    activeInput = null;
+    debugStarted = false;
+
+    workbench = new Workbench();
+    await workbench.executeCommand(startDebugCmd);
   });
 
-  after(async () => {
-      await input.cancel();
-  });  
+  afterEach(async () => {
+    if (activeInput) {
+      if (await activeInput.isDisplayed())
+        await activeInput.cancel();
+    }
 
-  // to verify that the Attach and Launch config items show up when starting to debug via. VS Code
-  it('should show debug config items on F5', async  function() {
-    this.timeout(15000);
+    if(debugStarted) {
+      await workbench.executeCommand(stopDebugCmd);
+    }
+  });
 
-    const workbench = new Workbench();
-    await workbench.executeCommand(startDebugCmd);
+  // to verify that the config item named "Attach" is really for attach mode
+  it('should show debug config items on F5', async function () {
+    const cmdInput = await getActiveInputBox();
+    expect(await cmdInput.isDisplayed()).is.true;
 
-    input = await InputBox.create();
-    expect(await input.isDisplayed()).is.true;
+    const picks = await cmdInput.getQuickPicks();
 
-    const picks = await input.getQuickPicks();
-
-    const attachCfg:InputBox[] = await findAll(picks, async (x:InputBox) => { return attachConfigText === await x.getText();});
+    const attachCfg: InputBox[] = await findAll(picks, async (x: InputBox) => { return attachConfigText === await x.getText(); });
     expect(attachCfg.length).equals(1);
 
-    const launchCfg:InputBox[] = await findAll(picks, async (x:InputBox) => { return launchConfigText === await x.getText();});
+    const launchCfg: InputBox[] = await findAll(picks, async (x: InputBox) => { return launchConfigText === await x.getText(); });
     expect(launchCfg.length).equals(1);
   });
 
-  async function findAll(array, callbackFind) : Promise<Array<InputBox>>{
-    let ret:Array<InputBox> = [];
+  // to verify that the "Attach" config item is bound to attach mode
+  it('should debug in attach mode after selecting Debug: Attach', async function () {
+    const cmdInput = await getActiveInputBox();
+    expect(await cmdInput.isDisplayed()).is.true;
 
-    for(const item of array) {
+    await cmdInput.setText(attachConfigText);
+    await cmdInput.confirm();
+
+    debugStarted = true;
+
+    const procInput = await getActiveInputBox();
+    expect((await procInput.getPlaceHolder()).startsWith(expectedAttachHint)).true;
+  });
+
+  // to verify that the config item named "Launch" is really for launch mode
+  it('should debug in launch mode after selecting Debug: Launch', async function () {
+    const cmdInput = await getActiveInputBox();
+    expect(await cmdInput.isDisplayed()).is.true;
+
+    await cmdInput.setText(launchConfigText);
+    await cmdInput.confirm();
+
+    debugStarted = true;
+
+    const procInput = await getActiveInputBox();
+    expect((await procInput.getPlaceHolder()).startsWith(expectedLaunchHint)).true;
+  });
+
+  async function findAll(array, callbackFind): Promise<Array<InputBox>> {
+    let ret: Array<InputBox> = [];
+
+    for (const item of array) {
       const matched: boolean = await callbackFind(item);
-      if(!matched)
+      if (!matched)
         continue;
-      
+
       ret.push(item);
     }
 
     return ret;
+  }
+
+  async function getActiveInputBox(): Promise<InputBox> {
+    let input = await InputBox.create();
+    activeInput = input;
+
+    return activeInput;
   }
 
 });

--- a/package.json
+++ b/package.json
@@ -617,7 +617,7 @@
 		"watch": "tsc -p -watch ./",
 		"test": "npm run compile && node ./out/test/runTest.js",
 		"cc": "npm run compile && node ./out/test/runTest.js --codecoverage",
-		"e2etest": "npm run compile && extest setup-and-run -c 1.50.0 ./out/test/e2e/*.js -m ./out/test/e2e/config.js"
+		"e2etest": "npm run compile && extest setup-and-run -c 1.50.0 ./out/test/e2e/*.js -m ./out/test/e2e/config.js -u"
 	},
 	"devDependencies": {
 		"@istanbuljs/nyc-config-typescript": "^1.0.1",


### PR DESCRIPTION
##### Objective
Same as title.

##### Abstractions
Two test cases are added:
- when 'Debug: Attach' is selected, we start in attach mode
- when 'Debug: Launch' is selected, we start in launch mode

Also updated package.json to uninstall AutolispExt after E2E tests are done, by adding "-u" opition.

##### Tests performed
The new added tests work as expected.

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
