### PR TITLE
Resolved Issue #70

### DIFF
--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -29,7 +29,7 @@ export class ContextManager{
 	get ExtPath(): string { 
 		return this._ctx ? this._ctx.extensionPath : ""; 
 	}
-	get Data() { 
+	get Resources() { 
 		return Resources; 
 	}
 

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -10,6 +10,7 @@ import { calculateABSPathForDAP } from './platform';
 import { existsSync } from 'fs';
 import { ProcessPathCache } from './process/processCache';
 import { DiagnosticsCtrl } from './diagnosticsCtrl';
+import { AutoLispExt } from './extension';
 
 let strNoADPerr: string = localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
 let strNoACADerr: string = localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
@@ -132,7 +133,7 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
         if (newConfig["type"] === launchCfgType) {
             // 1. get acad and adapter path
             // 2. get acadRoot path
-            let productPath = getExtensionSettingString(LAUNCH_PROC);
+            let productPath = AutoLispExt.Resources.getExtensionSettingString(LAUNCH_PROC);
 
             if (!productPath) {
                 let info = localize("autolispext.debug.launchjson.path",
@@ -167,7 +168,7 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
                 ProcessPathCache.globalProductPath = "";
                 return undefined;
             } else {
-                let params = getExtensionSettingString(LAUNCH_PARM);
+                let params = AutoLispExt.Resources.getExtensionSettingString(LAUNCH_PARM);
                 ProcessPathCache.globalParameter = params;
             }
 
@@ -207,7 +208,7 @@ class LispAttachConfigurationProvider implements vscode.DebugConfigurationProvid
             newConfig.program = vscode.window.activeTextEditor.document.fileName;
 
         ProcessPathCache.globalAcadNameInUserAttachConfig = '';
-        let name = getExtensionSettingString(ATTACH_PROC);
+        let name = AutoLispExt.Resources.getExtensionSettingString(ATTACH_PROC);
         if (name)
             ProcessPathCache.globalAcadNameInUserAttachConfig = name;
 
@@ -239,17 +240,6 @@ class LispAttachConfigurationProvider implements vscode.DebugConfigurationProvid
     }
 }
 
-function getExtensionSettingString(settingName: string): string {
-    let settingGroup = vscode.workspace.getConfiguration('autolispext');
-    if (!settingGroup)
-        return null;
-
-    let setting = settingGroup.get(settingName);
-    if (!setting)
-        return null;
-
-    return setting.toString().trim();
-}
 
 function rememberLaunchPath(path: string) {
     if (existsSync(path) == false)

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -10,7 +10,7 @@ import { calculateABSPathForDAP } from './platform';
 import { existsSync } from 'fs';
 import { ProcessPathCache } from './process/processCache';
 import { DiagnosticsCtrl } from './diagnosticsCtrl';
-import { AutoLispExt } from './extension';
+import { getExtensionSettingString } from './resources';
 
 let strNoADPerr: string = localize("autolispext.debug.nodap", "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.");
 let strNoACADerr: string = localize("autolispext.debug.noacad", "doesn’t exist. Verify and correct the folder path to the product executable.");
@@ -133,7 +133,7 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
         if (newConfig["type"] === launchCfgType) {
             // 1. get acad and adapter path
             // 2. get acadRoot path
-            let productPath = AutoLispExt.Resources.getExtensionSettingString(LAUNCH_PROC);
+            let productPath = getExtensionSettingString(LAUNCH_PROC);
 
             if (!productPath) {
                 let info = localize("autolispext.debug.launchjson.path",
@@ -168,7 +168,7 @@ class LispLaunchConfigurationProvider implements vscode.DebugConfigurationProvid
                 ProcessPathCache.globalProductPath = "";
                 return undefined;
             } else {
-                let params = AutoLispExt.Resources.getExtensionSettingString(LAUNCH_PARM);
+                let params = getExtensionSettingString(LAUNCH_PARM);
                 ProcessPathCache.globalParameter = params;
             }
 
@@ -208,7 +208,7 @@ class LispAttachConfigurationProvider implements vscode.DebugConfigurationProvid
             newConfig.program = vscode.window.activeTextEditor.document.fileName;
 
         ProcessPathCache.globalAcadNameInUserAttachConfig = '';
-        let name = AutoLispExt.Resources.getExtensionSettingString(ATTACH_PROC);
+        let name = getExtensionSettingString(ATTACH_PROC);
         if (name)
             ProcessPathCache.globalAcadNameInUserAttachConfig = name;
 

--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -247,11 +247,6 @@ export class LispContainer extends LispAtom {
     }
 
 
-    // Returns true if this LispContainer encapsulates the provided Position
-    contains(position: Position): boolean {
-        return this.getRange().contains(position);
-    }
-
 
     // This version was necessary to properly alternate over SETQ Name vs Value 
     private isValidForSetq(atom: ILispFragment): boolean {

--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -1100,7 +1100,7 @@ export class Sexpression extends LispAtom {
                     else if (opName == "setq") {
                         return exp.formatSetq(startColumn);
                     }
-                    else if (opName == "foreach") {
+                    else if (opName === "foreach" || opName === "vlax-for") {
                         return exp.formatForeach(startColumn);
                     }
                     else if (opName == "defun" || opName == "defun-q") {

--- a/extension/src/help/openWebHelp.ts
+++ b/extension/src/help/openWebHelp.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { AutoLispExt } from '../extension';
+import { getExtensionSettingString } from '../resources';
 import { IJsonLoadable, webHelpContainer } from "../resources";
 
 
@@ -37,7 +37,7 @@ export class WebHelpLibrary implements IJsonLoadable {
 	// Issue #70 requested user configuration of the help year
 	// 			 this implements the proposed solution of extracting it from the launch configuration
 	private getYearFromSettings(): string|null {
-		let acad = AutoLispExt.Resources.getExtensionSettingString('debug.LaunchProgram');
+		let acad = getExtensionSettingString('debug.LaunchProgram');
 		let qualifier = /(?<=AUTOCAD\s*)20\d{2}(?!ACAD.EXE)/i;
 		if (qualifier.test(acad)) {
 			return qualifier.exec(acad)[0];

--- a/extension/src/help/openWebHelp.ts
+++ b/extension/src/help/openWebHelp.ts
@@ -27,28 +27,23 @@ export class WebHelpLibrary implements IJsonLoadable {
 	functions: Dictionary<WebHelpFunction> = {};
 	ambiguousFunctions: Dictionary<WebHelpFunction[]> = {};
 	enumerators: Dictionary<string> = {};	
-	_fallbackYear: string;
+	_jsonYear: string = '';
+	
 	get year(): string {
-		// This was converted to a getter because WebHelpLibrary only loads once on start
-		// It would of required restart after changing the launch configuration to update the year
-		return this.getYearFromSettings() ?? this._fallbackYear;
+		return getExtensionSettingString('help.TargetYear');
 	}
 
-	// Issue #70 requested user configuration of the help year
-	//           this implements the proposed solution of extracting it from the launch configuration
-	private getYearFromSettings(): string|null {
-		let acad = getExtensionSettingString('debug.LaunchProgram');
-		let qualifier = /(?<=AUTOCAD\s*)20\d{2}(?!ACAD.EXE)/i;
-		if (qualifier.test(acad)) {
-			return qualifier.exec(acad)[0];
-		} else {
-			return null;
-		}
+	get jsonCreatedWithVersionYear(): string {
+		return this._jsonYear;
 	}
+
 
 	// consumes a JSON converted object into the WebHelpLibrary
 	loadFromJsonObject(obj: object): void{		
-		this._fallbackYear = obj['year'] ?? '2021';
+		// Issue #70, A user configured extension setting was requested by Issue #70 and deprecated the use of the embedded json year
+		//            However, this was left available in case we would like to setup a unit test that insures the JSON isn't stale.
+		this._jsonYear = obj['year'] ?? '2021';
+
 		Object.keys(obj["dclAttributes"]).forEach(key => {
 			let newObj = new WebHelpDclAtt(obj["dclAttributes"][key]);
 			this.dclAttributes[key] = newObj;

--- a/extension/src/help/openWebHelp.ts
+++ b/extension/src/help/openWebHelp.ts
@@ -35,7 +35,7 @@ export class WebHelpLibrary implements IJsonLoadable {
 	}
 
 	// Issue #70 requested user configuration of the help year
-	// 			 this implements the proposed solution of extracting it from the launch configuration
+	//           this implements the proposed solution of extracting it from the launch configuration
 	private getYearFromSettings(): string|null {
 		let acad = getExtensionSettingString('debug.LaunchProgram');
 		let qualifier = /(?<=AUTOCAD\s*)20\d{2}(?!ACAD.EXE)/i;

--- a/extension/src/resources.ts
+++ b/extension/src/resources.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { WebHelpLibrary } from "./help/openWebHelp";
+import * as vscode from 'vscode';
 
 
 export let internalLispFuncs: Array<string> = [];
@@ -78,4 +79,20 @@ function readDataFileByDelimiter(datafile: string, delimiter: string, action: (i
 			});
 		}
 	});
+}
+
+
+
+export function getExtensionSettingString(settingName: string): string {
+    let settingGroup = vscode.workspace.getConfiguration('autolispext');
+    if (!settingGroup) {
+        return null;
+	}
+
+    let setting = settingGroup.get(settingName);
+    if (!setting) {
+        return null;
+	}
+
+    return setting.toString().trim();
 }

--- a/i18n/chs/package.i18n.json
+++ b/i18n/chs/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "函数参数的窄格式样式中使用的缩进值。值必须在 1 和 6 之间。",
   "autolispext.configuration.closeparenstyle.desc": "控制右括号的样式。右括号与函数位于同一行或与函数的左括号对齐。",
   "autolispext.configuration.longlistformatstyle": "控制长列表的格式样式。函数的每个参数或多个参数都放置在单独的行上。",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "要针对“调试附加”过滤的进程名称。",
   "autolispext.configuration.launchprogram.desc": "AutoCAD 可执行文件的绝对路径。",
   "autolispext.configuration.launchparameters.desc": "AutoCAD 命令行启动开关。",

--- a/i18n/cht/package.i18n.json
+++ b/i18n/cht/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "函數引數的窄格式型式使用的縮排值。值必須在 1 到 6 的範圍內。",
   "autolispext.configuration.closeparenstyle.desc": "控制右圓括號的型式。右圓括號會放在與函數同一行的位置，或與函數的左圓括號對齊。",
   "autolispext.configuration.longlistformatstyle": "控制長清單的格式型式。函數的每個參數或多個參數都會放在單獨的一行。",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "要篩選以用於「偵錯連接」的程序名稱。",
   "autolispext.configuration.launchprogram.desc": "AutoCAD 可執行檔的絕對路徑。",
   "autolispext.configuration.launchparameters.desc": "AutoCAD 指令行啟動參數。",

--- a/i18n/deu/package.i18n.json
+++ b/i18n/deu/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Einrückungswert für den schmalen Formatierungsstil der Funktionsargumente. Wert muss zwischen 1 und 6 liegen.",
   "autolispext.configuration.closeparenstyle.desc": "Steuert den Stil schließender Klammern. Die schließende Klammer wird auf derselben Zeile platziert wie die Funktion oder an der öffnenden Klammer der Funktion ausgerichtet.",
   "autolispext.configuration.longlistformatstyle": "Steuert den Formatstil von langen Listen. Jeder oder mehrere Parameter einer Funktion werden in separaten Zeilen platziert.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Prozessname, nach dem für Debug Attach gefiltert werden soll.",
   "autolispext.configuration.launchprogram.desc": "Absoluter Pfad zur ausführbaren AutoCAD-Datei.",
   "autolispext.configuration.launchparameters.desc": "AutoCAD-Befehlszeilenstartoptionen.",

--- a/i18n/enu/package.i18n.json
+++ b/i18n/enu/package.i18n.json
@@ -8,6 +8,7 @@
 	"autolispext.configuration.narrowstyleindent.desc": "Indentation value used in the Narrow Formatting Style of function arguments. Value must be in the range of 1 and 6.",
 	"autolispext.configuration.closeparenstyle.desc": "Controls the style of closing parenthesis. Closing parenthesis is placed on the same line as the function or aligned with the function’s opening parenthesis.",
 	"autolispext.configuration.longlistformatstyle": "Controls the format style of long lists. Each or multiple parameters of a function are placed on separate lines.",
+	"autolispext.configuration.helptargetyear": "",
 	"autolispext.configuration.attachprocess.desc": "Process name to filter on for Debug Attach.",
 	"autolispext.configuration.launchprogram.desc": "Absolute path to the AutoCAD executable.",
 	"autolispext.configuration.launchparameters.desc": "AutoCAD command line startup switches.",

--- a/i18n/esp/package.i18n.json
+++ b/i18n/esp/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Valor de sangría utilizado en el estilo de formato estrecho de los argumentos de función. El valor debe encontrarse en el intervalo entre 1 y 6.",
   "autolispext.configuration.closeparenstyle.desc": "Controla el estilo del paréntesis de cierre. El paréntesis de cierre se coloca en la misma línea que la función o se alinea con el paréntesis de apertura de la función.",
   "autolispext.configuration.longlistformatstyle": "Controla el estilo de formato de las listas largas. Uno o varios parámetros de una función se colocan en líneas independientes.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Nombre del proceso por el que filtrar para Debug Attach.",
   "autolispext.configuration.launchprogram.desc": "Ruta absoluta al archivo ejecutable de AutoCAD.",
   "autolispext.configuration.launchparameters.desc": "Conmutadores de inicio de la línea de comando de AutoCAD.",

--- a/i18n/fra/package.i18n.json
+++ b/i18n/fra/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Valeur de retrait utilisée dans les arguments de la fonction Style de formatage étroit. La valeur doit être comprise entre 1 et 6.",
   "autolispext.configuration.closeparenstyle.desc": "Contrôle le style de parenthèse fermante. La parenthèse fermante est placée sur la même ligne que la fonction ou alignée sur la parenthèse ouvrante de la fonction.",
   "autolispext.configuration.longlistformatstyle": "Contrôle le style de format des listes longues. Chaque paramètre, ou plusieurs paramètres, d'une fonction sont placés sur des lignes distinctes.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Nom du processus sur lequel filtrer pour Debug Attach.",
   "autolispext.configuration.launchprogram.desc": "Chemin absolu de l'exécutable d'AutoCAD.",
   "autolispext.configuration.launchparameters.desc": "Commutateurs de démarrage de ligne de commande d'AutoCAD.",

--- a/i18n/hun/package.i18n.json
+++ b/i18n/hun/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "A függvényargumentumok keskeny formázási stílusában használt behúzási érték. Az értéknek 1 és 6 között kell lennie.",
   "autolispext.configuration.closeparenstyle.desc": "A záró zárójel stílusát szabályozza. A záró zárójel a függvénnyel azonos sorba kerül, vagy a függvény nyitó zárójeléhez van igazítva.",
   "autolispext.configuration.longlistformatstyle": "A hosszú listák formátumstílusát szabályozza. A függvények minden vagy több paramétere külön sorba kerül.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Folyamatnév a szűréshez a Debug Attach konfiguráció esetében.",
   "autolispext.configuration.launchprogram.desc": "Az AutoCAD futtatható fájljának abszolút elérési útvonala.",
   "autolispext.configuration.launchparameters.desc": "AutoCAD parancssori indítási kapcsolók.",

--- a/i18n/ita/package.i18n.json
+++ b/i18n/ita/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Valore di rientro utilizzato nello stile di formattazione stretto degli argomenti di funzione. Il valore deve essere compreso nell'intervallo 1-6.",
   "autolispext.configuration.closeparenstyle.desc": "Controlla lo stile della parentesi di chiusura. La parentesi di chiusura viene inserita sulla stessa riga della funzione o allineata con la parentesi di apertura della funzione.",
   "autolispext.configuration.longlistformatstyle": "Controlla lo stile del formato degli elenchi lunghi. Ogni parametro o più parametri di una funzione vengono posizionati su righe separate.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Nome del processo in base al quale filtrare per Debug Attach.",
   "autolispext.configuration.launchprogram.desc": "Percorso assoluto del file eseguibile di AutoCAD.",
   "autolispext.configuration.launchparameters.desc": "Opzioni di avvio dalla riga di comando di AutoCAD.",

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "関数の引数の幅狭整形スタイルで使用されるインデント値。値は 1 ~ 6 の範囲でなければなりません。",
   "autolispext.configuration.closeparenstyle.desc": "右括弧のスタイルをコントロールします。右括弧は、関数と同じ行に配置されるか、関数の左括弧に位置合わせて配置されます。",
   "autolispext.configuration.longlistformatstyle": "長いリストの整形スタイルをコントロールします。関数の各パラメータまたは複数のパラメータは、別々の行に配置されます。",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "デバッグ アタッチ用にフィルタするプロセス名。",
   "autolispext.configuration.launchprogram.desc": "AutoCAD 実行ファイルへの絶対パス。",
   "autolispext.configuration.launchparameters.desc": "AutoCAD コマンド ライン起動スイッチ。",

--- a/i18n/kor/package.i18n.json
+++ b/i18n/kor/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "함수 인수의 좁은 형식 스타일에 사용되는 들여쓰기 값입니다. 값은 1과 6 범위 내에 있어야 합니다.",
   "autolispext.configuration.closeparenstyle.desc": "닫는 괄호의 스타일을 조정합니다. 닫는 괄호는 함수와 같은 행에 배치되거나 함수의 여는 괄호에 정렬됩니다.",
   "autolispext.configuration.longlistformatstyle": "긴 리스트의 형식 스타일을 조정합니다. 함수의 각 또는 여러 매개변수는 별도의 행에 배치됩니다.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Debug Attach에 대해 필터링할 프로세스 이름입니다.",
   "autolispext.configuration.launchprogram.desc": "AutoCAD 실행 파일의 절대 경로입니다.",
   "autolispext.configuration.launchparameters.desc": "AutoCAD 명령행 시작 스위치입니다.",

--- a/i18n/ptb/package.i18n.json
+++ b/i18n/ptb/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Valor de recuo usado no Estilo de formatação estreito dos argumentos de função. O valor deve estar na faixa de 1 e 6.",
   "autolispext.configuration.closeparenstyle.desc": "Controla o estilo de parênteses de fechamento. O parêntese de fechamento é colocado na mesma linha que a função ou alinhado com o parêntese de abertura da função.",
   "autolispext.configuration.longlistformatstyle": "Controla o estilo de formato de listas longas. Cada parâmetro ou vários parâmetros de uma função são inseridos em linhas separadas.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Nome do processo a ser filtrado para anexar a depuração.",
   "autolispext.configuration.launchprogram.desc": "Caminho absoluto para o executável do AutoCAD.",
   "autolispext.configuration.launchparameters.desc": "Botões de inicialização da linha de comando do AutoCAD.",

--- a/i18n/rus/package.i18n.json
+++ b/i18n/rus/package.i18n.json
@@ -8,6 +8,7 @@
   "autolispext.configuration.narrowstyleindent.desc": "Значение отступа, используемое в узком стиле форматирования аргументов функции. Значение должно находиться в диапазоне от 1 до 6.",
   "autolispext.configuration.closeparenstyle.desc": "Управление стилем закрывающей скобки. Закрывающая скобка помещается на той же строке, что и функция, или выравнивается по открывающей скобке функции.",
   "autolispext.configuration.longlistformatstyle": "Управление стилем форматирования длинных списков. Каждый или несколько параметров функции размещаются на отдельных строках.",
+  "autolispext.configuration.helptargetyear": "",
   "autolispext.configuration.attachprocess.desc": "Имя процесса для фильтрации в Debug Attach.",
   "autolispext.configuration.launchprogram.desc": "Абсолютный путь к исполняемому файлу AutoCAD.",
   "autolispext.configuration.launchparameters.desc": "Переключатели запуска командной строки AutoCAD.",

--- a/package.json
+++ b/package.json
@@ -221,6 +221,18 @@
 					"type": "string",
 					"default": "",
 					"description": "%autolispext.configuration.launchparameters.desc%"
+				},
+				"autolispext.help.TargetYear": {
+					"type": "string",
+					"enum": [
+						"2018",
+						"2019",
+						"2020",
+						"2021",
+						"2022"
+					],
+					"default": "2022",
+					"description": "%autolispext.configuration.helptargetyear%"
 				}
 			}
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
 	"autolispext.configuration.narrowstyleindent.desc": "Indentation value used in the Narrow Formatting Style of function arguments. Value must be in the range of 1 and 6.",
 	"autolispext.configuration.closeparenstyle.desc": "Controls the style of closing parenthesis. Closing parenthesis is placed on the same line as the function or aligned with the function’s opening parenthesis.",
 	"autolispext.configuration.longlistformatstyle": "Controls the format style of long lists. Each or multiple parameters of a function are placed on separate lines.",
+	"autolispext.configuration.helptargetyear": "Determines the targeted AutoCAD year version of the 'Open Online Help' command.",
 	"autolispext.configuration.attachprocess.desc": "Process name to filter on for Debug Attach.",
 	"autolispext.configuration.launchprogram.desc": "Absolute path to the AutoCAD executable.",
 	"autolispext.configuration.launchparameters.desc": "AutoCAD command line startup switches.",


### PR DESCRIPTION
#### Objective
Issue #70 requested user control over the help URL year. The proposed solution was to extract this from the Launch Path Configuration. This implements that request and a few other minor refactors.

#### Abstractions
The function we had for reading our Configuration Settings was not exported and lived in the `debug.ts` file. This was relocated to `resources.ts`, flagged as an export and the `debug.ts` was updated to use the new shared location.

#### Tests performed
Manually tested this and it pulled up the expected result by changing the launch configurations to:
* empty
* C:\Program Files\Autodesk\AutoCAD 2019\acad.exe
* C:\Program Files\Autodesk\AutoCAD 2020\acad.exe
* C:\Program Files\Autodesk\AutoCAD 2021\acad.exe
* C:\Program Files\Autodesk\AutoCAD 2022\acad.exe
* C:\Program Files\Autodesk\AutoCAD 2023\acad.exe (this produces not found)

