### PR TITLE
To hook e2e tests on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,10 @@ jobs:
         run: npm test
         if: runner.os != 'Linux'
 
+      - name: Run e2e tests
+        run: npm run e2etest
+        if: runner.os != 'Linux'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:


### PR DESCRIPTION
##### Objective
Same as title.

##### Abstractions
Add a "Run e2e tests" step on the CI to run the end to end tests we currently have.
It's added after step "Run tests on Windows OS"(npm test) and before CodeQL steps.

##### Tests performed

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
![image](https://user-images.githubusercontent.com/57521938/113669889-f90dae80-96e6-11eb-8682-0d077ea5ae9b.png)
