### PR TITLE
Fix the CodeQL very slow issue

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,8 +7,7 @@ paths:
 - '**/extension/src/**'
 
 paths-ignore:
-- '**/.vscode-test/**'
+  - '**/.vscode-test/**'
   - '**/.vscode-test/**'
   - '**/AutoLispExt/out/**/*.js'
   - '**/test-resources/**'
-  

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,3 +8,7 @@ paths:
 
 paths-ignore:
 - '**/.vscode-test/**'
+  - '**/.vscode-test/**'
+  - '**/AutoLispExt/out/**/*.js'
+  - '**/test-resources/**'
+  

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,13 +1,12 @@
 name: "Custom CodeQL Config"
 
 queries:
-- uses: security-and-quality
+  - uses: security-and-quality
 
 paths:
-- '**/extension/src/**'
+  - '**/extension/src/**'
 
 paths-ignore:
   - '**/.vscode-test/**'
-  - '**/.vscode-test/**'
-  - '**/AutoLispExt/out/**/*.js'
+  - '**/AutoLispExt/out/**'
   - '**/test-resources/**'


### PR DESCRIPTION
##### Objective
Recently it takes very long time(~50 minutes) to run the codeql on Github CI due to the test-resources folder
##### Abstractions
Add the test-resources folder to the configure file codeql-config.yml so that the codeql will not scan it.
##### Tests performed
Passed local test and Github CI

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
