### PR TITLE
Add the format selection unit test cases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,11 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
-            ]
+            ],
+            "skipFiles": [
+                "${workspaceFolder}/node_modules/**/*.js",
+                "<node_internals>/**/*.js"
+              ]
         },
         {
             "name": "Extension Tests + Reporting",

--- a/extension/src/test/Baseline/formatedBasefile17.lsp
+++ b/extension/src/test/Baseline/formatedBasefile17.lsp
@@ -1,0 +1,64 @@
+
+(defun c:flower( / R1 n1 n2 pt1 pt2 pt3 pt4 pt5)
+(princ "中文测试")
+  (setq lst '("abc" nil nil 1 nil 10 nil 12))
+  (setq centerPt0 (getpoint "\n Please pick point in screen")
+        R1        5
+        R2        (* 2 R1)
+        R3        R1
+        n1        6
+        n2        12
+        2p        (* 2 PI)
+        ang       (/ 360.0 n1)
+        ang30     (* PI (/ 30 180.0))
+        ang60     (* PI (/ 60 180.0))
+        ang120    (* PI (/ 120 180.0))
+        ang150    (* PI (/ 150 180.0))
+        color     3
+        width     5
+  )
+	(princ a)
+	
+  (setq pt1 centerPt0
+    pt2 (list (car pt1) (+ (cadr pt1) R1))
+    pt3 (polar pt1 ang60 R1 )
+    centerPt1 (polar pt1 ang30 R1 )
+    centerPt2 (polar pt1 ang120 R1 )
+    centerPt3 (polar pt1 ang150 R1 )
+    pt4 (polar centerPt2 ang30 R1 )
+    pt5 (polar pt2 ang60 R1 )
+    
+  )
+  
+  (SETQ ss1 (ssadd))
+  (Command "_Arc" pt2 "_C" centerPt1 "_A" 60)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt1 "_C" centerPt3 "_A" 60)
+  (ssadd (entlast) ss1)
+  (command "_-hatch" "_p" "solid" "_s" ss1 "" "_co" "40" "" "")
+  (ssadd (entlast) ss1)
+  (command "_array" ss1 "" "_polar" centerPt0 n1 "360" "_y")
+  (setq ss1 nil)
+  (setq ss1 nil)
+  (setq ss1 (ssadd))
+  
+  (Command "_Arc" pt4 "_C" centerPt1 "_A" 30)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt3 "_C" centerPt2 "_A" 30)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt3 "_C" centerPt0 "_A" 30)
+  (ssadd (entlast) ss1)
+  
+  (command "_-hatch" "_p" "solid" "_s" ss1 "" "_co" "222" "" "")
+  (ssadd (entlast) ss1)
+  (command "_array" ss1 "" "_polar" centerPt0 n2 "360" "_y")
+  
+  (setq ss1 nil)
+  (setq ss1 (ssadd))
+  (Command "_Arc" pt5 "_C" pt2 "_A" 60)
+  (ssadd (entlast) ss1)
+  
+  (command "_array" ss1 "" "_polar" centerPt0 n2 "360" "_y")
+  (princ)
+  
+)

--- a/extension/src/test/Baseline/formatedBasefile18.lsp
+++ b/extension/src/test/Baseline/formatedBasefile18.lsp
@@ -1,0 +1,16 @@
+(defun cleanvirus ( / lspfiles lspfile x)
+  (setq lspfiles 
+         '("acad.vlx" "logo.gif" "acad"))
+  (foreach lspfile lspfiles
+    (while (setq x (findfile lspfile)) 
+      (progn 
+        (vl-file-delete x)
+        (princ "\n Delete file ")
+        (princ x)
+      ) ;progn
+    );while
+  
+  );foreach
+  
+)
+(cleanvirus)

--- a/extension/src/test/Baseline/formatedBasefile19.lsp
+++ b/extension/src/test/Baseline/formatedBasefile19.lsp
@@ -1,0 +1,15 @@
+(defun c:formatTest (/ *error* a b  cen dpr ent lst ocs ofe off tmp 
+                        vpe vpt) 
+  (setq a 3)
+  (setq b 
+      "test")
+  (princ a)
+      (princ b)
+      (setq lst (reverse 
+                    (mapcar 
+                        '(lambda (a b) 
+                             (cons (car a) 
+                                   (cons 42 (- (cddr b)))))
+                        lst
+                        (cons (last lst) lst))))
+)

--- a/extension/src/test/SourceFile/unFormatted17.lsp
+++ b/extension/src/test/SourceFile/unFormatted17.lsp
@@ -1,0 +1,66 @@
+
+(defun c:flower( / R1 n1 n2 pt1 pt2 pt3 pt4 pt5)
+(princ "中文测试")
+  (setq lst '("abc" nil nil 1 nil 10 nil 12))
+  (setq centerPt0 (getpoint "\n Please pick point in screen")
+    R1 5
+    R2 (* 2 R1)
+    R3 R1
+    n1 6      
+    n2 12
+    2p (* 2 PI)
+    ang (/ 360.0 n1)
+    ang30 (* PI (/ 30 180.0))
+    ang60 (* PI (/ 60 180.0))
+    ang120 (* PI (/ 120 180.0))
+    ang150 (* PI (/ 150 180.0))
+    color 3
+    width 5
+        
+    
+  )
+	(princ a)
+	
+  (setq pt1 centerPt0
+    pt2 (list (car pt1) (+ (cadr pt1) R1))
+    pt3 (polar pt1 ang60 R1 )
+    centerPt1 (polar pt1 ang30 R1 )
+    centerPt2 (polar pt1 ang120 R1 )
+    centerPt3 (polar pt1 ang150 R1 )
+    pt4 (polar centerPt2 ang30 R1 )
+    pt5 (polar pt2 ang60 R1 )
+    
+  )
+  
+  (SETQ ss1 (ssadd))
+  (Command "_Arc" pt2 "_C" centerPt1 "_A" 60)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt1 "_C" centerPt3 "_A" 60)
+  (ssadd (entlast) ss1)
+  (command "_-hatch" "_p" "solid" "_s" ss1 "" "_co" "40" "" "")
+  (ssadd (entlast) ss1)
+  (command "_array" ss1 "" "_polar" centerPt0 n1 "360" "_y")
+  (setq ss1 nil)
+  (setq ss1 nil)
+  (setq ss1 (ssadd))
+  
+  (Command "_Arc" pt4 "_C" centerPt1 "_A" 30)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt3 "_C" centerPt2 "_A" 30)
+  (ssadd (entlast) ss1)
+  (Command "_Arc" pt3 "_C" centerPt0 "_A" 30)
+  (ssadd (entlast) ss1)
+  
+  (command "_-hatch" "_p" "solid" "_s" ss1 "" "_co" "222" "" "")
+  (ssadd (entlast) ss1)
+  (command "_array" ss1 "" "_polar" centerPt0 n2 "360" "_y")
+  
+  (setq ss1 nil)
+  (setq ss1 (ssadd))
+  (Command "_Arc" pt5 "_C" pt2 "_A" 60)
+  (ssadd (entlast) ss1)
+  
+  (command "_array" ss1 "" "_polar" centerPt0 n2 "360" "_y")
+  (princ)
+  
+)

--- a/extension/src/test/SourceFile/unFormatted18.lsp
+++ b/extension/src/test/SourceFile/unFormatted18.lsp
@@ -1,0 +1,17 @@
+(defun cleanvirus ( / lspfiles lspfile x)
+  (setq lspfiles 
+         '("acad.vlx" "logo.gif" "acad"))
+  (foreach lspfile lspfiles
+    (while (setq x 
+                  (findfile lspfile))
+    (progn
+    (vl-file-delete x)
+      (princ "\n Delete file ")
+      (princ x)
+    );progn
+    );while
+  
+  );foreach
+  
+)
+(cleanvirus)

--- a/extension/src/test/SourceFile/unFormatted19.lsp
+++ b/extension/src/test/SourceFile/unFormatted19.lsp
@@ -1,0 +1,18 @@
+(defun c:formatTest (/ *error* a b  cen dpr ent lst ocs ofe off tmp 
+                        vpe vpt) 
+  (setq a 3)
+  (setq b 
+      "test")
+  (princ a)
+      (princ b)
+      (setq lst (reverse 
+            (mapcar 
+              '(lambda (a b) 
+                 (cons (car a) (cons 42 (- (cddr b))))
+               )
+              lst
+              (cons (last lst) lst)
+            )
+          )
+)
+)

--- a/extension/src/test/suite/Formatter.test.ts
+++ b/extension/src/test/suite/Formatter.test.ts
@@ -76,7 +76,7 @@ suite("Lisp Formatter mock Tests", function () {
 
   setup(()=>{
     resetDefault();
-  })
+  });
 
   teardown(() => {
     internalLispFuncsStub.restore();

--- a/extension/src/test/suite/Formatter.test.ts
+++ b/extension/src/test/suite/Formatter.test.ts
@@ -62,7 +62,7 @@ suite("Lisp Formatter mock Tests", function () {
   let internalLispFuncsStub;
   let internalOperators;
 
-  setup(async () => {
+  suiteSetup(() => {
     let keyFile = path.join(
       __dirname + "/../../../extension/data/alllispkeys.txt"
     );
@@ -72,11 +72,11 @@ suite("Lisp Formatter mock Tests", function () {
       "internalLispFuncs",
       internalOperators
     );
-    closeParenStyleStub.restore();
-    maximumLineCharsStub.restore();
-    longListFormatStyleStub.restore();
-    indentSpacesStub.restore();
   });
+
+  setup(()=>{
+    resetDefault();
+  })
 
   teardown(() => {
     internalLispFuncsStub.restore();
@@ -87,12 +87,6 @@ suite("Lisp Formatter mock Tests", function () {
     maximumLineCharsStub.restore();
     longListFormatStyleStub.restore();
     indentSpacesStub.restore();
-  });
-  suiteSetup(async () => {
-    setClosedParenInSameLine('New line with outer indentation');
-    setMaxLineChars(85);
-    setLongListFormat('Fill to margin');
-    setIndentSpaces(2);
   });
 
   test("Lisp Formatter Test case 1", function () {
@@ -429,5 +423,11 @@ suite("Lisp Formatter mock Tests", function () {
       "longListFormatStyle",
       LongListFormat
     );
+  }
+  function resetDefault(){
+    setClosedParenInSameLine('New line with outer indentation');
+    setMaxLineChars(85);
+    setLongListFormat('Fill to margin');
+    setIndentSpaces(2);
   }
 });

--- a/extension/src/test/suite/Formatter.test.ts
+++ b/extension/src/test/suite/Formatter.test.ts
@@ -1,12 +1,12 @@
 import * as chai from "chai";
 import * as fs from "fs";
 import * as path from "path";
-import { beforeEach } from "mocha";
 import { LispFormatter } from "../../format/formatter";
 import { ReadonlyDocument } from "../../project/readOnlyDocument";
 import * as fmtConfig from "../../format/fmtconfig";
 import { ImportMock } from "ts-mock-imports";
 import * as resources from "../../resources";
+import * as vscode from 'vscode';
 
 let assert = chai.assert;
 let testDir = path.join(__dirname + "/../../../extension/src/test");
@@ -62,7 +62,7 @@ suite("Lisp Formatter mock Tests", function () {
   let internalLispFuncsStub;
   let internalOperators;
 
-  setup(() => {
+  setup(async () => {
     let keyFile = path.join(
       __dirname + "/../../../extension/data/alllispkeys.txt"
     );
@@ -72,13 +72,12 @@ suite("Lisp Formatter mock Tests", function () {
       "internalLispFuncs",
       internalOperators
     );
-  });
-  beforeEach(async () => {
     closeParenStyleStub.restore();
     maximumLineCharsStub.restore();
     longListFormatStyleStub.restore();
     indentSpacesStub.restore();
   });
+
   teardown(() => {
     internalLispFuncsStub.restore();
   });
@@ -225,6 +224,7 @@ suite("Lisp Formatter mock Tests", function () {
     // Test long list and big file - chinaMap.lsp
     // This test will take long time
     let i = 10;
+    this.timeout(20000);
     try {
       const [source, output, baseline] = getFileName(i);
       let doc = ReadonlyDocument.open(source);
@@ -329,6 +329,61 @@ suite("Lisp Formatter mock Tests", function () {
       setIndentSpaces(8);
       setMaxLineChars(30);
       let fmt = LispFormatter.format(doc, null);
+      comparefileSync(i, output, fmt, baseline);
+    } catch (err) {
+      assert.fail(`The lisp format test case ${i} failed`);
+    }
+  });
+
+  test("Lisp Formatter Test case 17", function () {
+    //Test format selection
+    let i = 17;
+    try {
+      const [source, output, baseline] = getFileName(i);
+      const doc = ReadonlyDocument.open(source);
+      let anchor = new vscode.Position(4,2);
+      let active = new vscode.Position(20,4);
+      let selectedRange = new vscode.Selection(anchor,active);
+      let fmt = LispFormatter.format(doc, selectedRange);
+      fmt = doc.getText().replace(doc.getText(selectedRange),fmt);
+      comparefileSync(i, output, fmt, baseline);
+    } catch (err) {
+      assert.fail(`The lisp format test case ${i} failed`);
+    }
+  });
+
+  test("Lisp Formatter Test case 18", function () {
+    //Test format selection - inverse selection
+    let i = 18;
+    try {
+      const [source, output, baseline] = getFileName(i);
+      const doc = ReadonlyDocument.open(source);
+      let anchor = new vscode.Position(11,12);
+      let active = new vscode.Position(4,4);
+      let selectedRange = new vscode.Selection(anchor,active);
+      let fmt = LispFormatter.format(doc, selectedRange);
+      fmt = doc.getText().replace(doc.getText(selectedRange),fmt);
+      comparefileSync(i, output, fmt, baseline);
+    } catch (err) {
+      assert.fail(`The lisp format test case ${i} failed`);
+    }
+  });
+
+  test("Lisp Formatter Test case 19", function () {
+    //Test format selection - plus some format setting
+    let i = 19;
+    try {
+      const [source, output, baseline] = getFileName(i);
+      const doc = ReadonlyDocument.open(source);
+      let anchor = new vscode.Position(7,6);
+      let active = new vscode.Position(16,2);
+      let selectedRange = new vscode.Selection(anchor,active);
+      setClosedParenInSameLine("same line");
+      setIndentSpaces(4);
+      setMaxLineChars(65);
+      setLongListFormat("single column");
+      let fmt = LispFormatter.format(doc, selectedRange);
+      fmt = doc.getText().replace(doc.getText(selectedRange),fmt);
       comparefileSync(i, output, fmt, baseline);
     } catch (err) {
       assert.fail(`The lisp format test case ${i} failed`);

--- a/extension/src/test/suite/Formatter.test.ts
+++ b/extension/src/test/suite/Formatter.test.ts
@@ -78,11 +78,8 @@ suite("Lisp Formatter mock Tests", function () {
     resetDefault();
   });
 
-  teardown(() => {
+  suiteTeardown(() => {
     internalLispFuncsStub.restore();
-  });
-
-  suiteTeardown(async () => {
     closeParenStyleStub.restore();
     maximumLineCharsStub.restore();
     longListFormatStyleStub.restore();


### PR DESCRIPTION
##### Objective
Added the format selection unit test cases.
##### Abstractions
Form a vscode position to get the  selection and then do the format.
##### Tests performed
Passed local test and Github CI

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
