### PR TITLE
Update an error message to include the requirement on ACAD version

### DIFF
--- a/i18n/enu/out/debug.i18n.json
+++ b/i18n/enu/out/debug.i18n.json
@@ -1,5 +1,5 @@
 {
-  "autolispext.debug.nodap": "doesn’t exist. Verify that the file exists in the same folder as that for the product specified in the launch.json file.",
+  "autolispext.debug.nodap": "doesn’t exist. Use a release later than AutoCAD 2020. Verify that the file exists in the same folder as that for the product selected to attach.",
   "autolispext.debug.noacad": "doesn’t exist. Verify and correct the folder path to the product executable.",
   "autolispext.debug.acad.nosupport": "This instance of AutoCAD doesn’t support debugging AutoLISP files, use a release later than AutoCAD 2020.",
   "autolispext.debug.launchjson.path": "Specify the absolute path to the product with the Path attribute of the launch.json file.",

--- a/i18n/enu/out/debug.i18n.json
+++ b/i18n/enu/out/debug.i18n.json
@@ -1,5 +1,5 @@
 {
-  "autolispext.debug.nodap": "doesn’t exist. Use a release later than AutoCAD 2020. Verify that the file exists in the same folder as that for the product selected to attach.",
+  "autolispext.debug.nodap": "doesn’t exist. Use a release later than AutoCAD 2020. Verify that the file exists in the same folder as that for the product to debug.",
   "autolispext.debug.noacad": "doesn’t exist. Verify and correct the folder path to the product executable.",
   "autolispext.debug.acad.nosupport": "This instance of AutoCAD doesn’t support debugging AutoLISP files, use a release later than AutoCAD 2020.",
   "autolispext.debug.launchjson.path": "Specify the absolute path to the product with the Path attribute of the launch.json file.",

--- a/i18n/enu/out/debug.i18n.json
+++ b/i18n/enu/out/debug.i18n.json
@@ -1,5 +1,5 @@
 {
-  "autolispext.debug.nodap": "doesn’t exist. Use a release later than AutoCAD 2020. Verify that the file exists in the same folder as that for the product to debug.",
+  "autolispext.debug.nodap": "doesn’t exist. Use a release later than AutoCAD 2020. Verify that the file exists in the same folder with the product to debug.",
   "autolispext.debug.noacad": "doesn’t exist. Verify and correct the folder path to the product executable.",
   "autolispext.debug.acad.nosupport": "This instance of AutoCAD doesn’t support debugging AutoLISP files, use a release later than AutoCAD 2020.",
   "autolispext.debug.launchjson.path": "Specify the absolute path to the product with the Path attribute of the launch.json file.",


### PR DESCRIPTION
##### Objective
This is to solve this issue: https://github.com/Autodesk-AutoCAD/AutoLispExt/issues/129

##### Abstractions
This is to solve this issue: https://github.com/Autodesk-AutoCAD/AutoLispExt/issues/129
Currently when starting to debug LISP with an old version of AutoCAD, it will fail on file-not-found-error of debug adapter. The error message doesn't tell user that it's possibly because that a newer version of AutoCAD is needed.

A short hint is added into the error message for this possibility.

##### Tests performed
The bug is gone.

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
