### PR TITLE
Fix ACD-19624: we should not append extra whitespace before right paren at the end of line

### DIFF
--- a/extension/src/format/sexpression.ts
+++ b/extension/src/format/sexpression.ts
@@ -822,8 +822,12 @@ export class Sexpression extends LispAtom {
         }
 
         // Last atom may be )
-        if (hasCloseParen)
-            res += this.formatLastAtom(startColumn, columnWidth, this.isMultilineString(res));
+        if (hasCloseParen) {
+            let str2Append = this.formatLastAtom(startColumn, columnWidth, this.isMultilineString(res));
+            if(str2Append === ')')
+                res = res.trimRight(); // to avoid extra whitespace before the closing paren.
+            res += str2Append;
+        }
 
         return res;
     }

--- a/extension/src/test/Baseline/formatedBasefile16.lsp
+++ b/extension/src/test/Baseline/formatedBasefile16.lsp
@@ -2,7 +2,7 @@
 (defun c:flower (/ R1 n1 n2 pt1 pt2 pt3 pt4 pt5) 
       (princ "中文测试")
       (setq lst '("abc" nil nil 1 nil 10 nil 12))
-      (setq centerPt0 (getpoint "\n Please pick point in screen" )
+      (setq centerPt0 (getpoint "\n Please pick point in screen")
             R1        5
             R2        (* 2 R1)
             R3        R1

--- a/extension/src/test/Baseline/formatedBasefile5.lsp
+++ b/extension/src/test/Baseline/formatedBasefile5.lsp
@@ -3,7 +3,7 @@
                        ) 
 
   (defun *error* (msg) 
-    (if (not (wcmatch (strcase msg t) "*break,*cancel*,*exit*") ) 
+    (if (not (wcmatch (strcase msg t) "*break,*cancel*,*exit*")) 
       (princ (strcat "\nError: " msg))
     )
     (princ)


### PR DESCRIPTION
##### Objective
Fix ACD-19624: we should not append extra whitespace before right paren at the end of line

##### Abstractions
As shown in the diff of formatedBasefile5.lsp in this PR, previously, when formatting the test file, an extra whitespace was noticed before the right paren at the end of current line:
![image](https://user-images.githubusercontent.com/57521938/116367075-8604dd00-a839-11eb-8db6-ec7d3c189de3.png)

This is because for all atoms of a given line - except the last atom, a whitespace was appended by [the code here](https://github.com/Autodesk-AutoCAD/AutoLispExt/blob/d0182cb9555f7b2afe5e453b8e3411aa213f3938/extension/src/format/sexpression.ts#L772).

The fix is to call trimRight(), as lone as the ending atom of current line is a closing paren.

##### Tests performed
The bug is gone.
npm run test is green.

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
