### PR TITLE
Update the "debuggers->languages" part of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,29 +369,8 @@
 					"program": "${lispadapterpath}"
 				},
 				"languages": [
-					{
-						"id": "autolisp",
-						"aliases": [
-							"AutoLISP",
-							"autolisp"
-						],
-						"extensions": [
-							".lsp",
-							".mnl"
-						],
-						"configuration": "./extension/smartBracket/language-configuration.json"
-					},
-					{
-						"id": "autolispdcl",
-						"aliases": [
-							"AutoLISPDCL",
-							"autolispdcl"
-						],
-						"extensions": [
-							".dcl"
-						],
-						"configuration": "./extension/smartBracket/language-configuration-dcl.json"
-					}
+					"autolisp",
+					"autolispdcl"
 				],
 				"configurationAttributes": {
 					"attach": {


### PR DESCRIPTION
##### Objective
Update the "debuggers->languages" part of package.json

##### Abstractions
During the discussion in https://github.com/microsoft/vscode/issues/123881, @isidorn found that the "languages" in the "debuggers" part of package.json were over defined - we just need to list language id, instead of language object.

With this change applied, the bug https://github.com/Autodesk-AutoCAD/AutoLispExt/issues/143 is partially solved - now if there's a .lsp file opened, when pressing F5 to debug with VS Code 1.56.2, it doesn't require the existence of configuration file anymore.

##### Tests performed
Tested on VS Code 1.56.2 and 1.54.3; it's able attach to autocad on both of them (with a .lsp file opened).

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
