### PR TITLE
Hide an incomplete setting for making AutolispExt ver1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,11 +238,6 @@
 					],
 					"default": "2022",
 					"description": "%autolispext.configuration.helptargetyear%"
-				},
-				"autolispext.completion.FilterMacOS": {
-					"type": "boolean",
-					"default": true,
-					"description": "%autolispext.configuration.macfilter.desc%"
 				}
 			}
 		},


### PR DESCRIPTION
##### Objective
Hide an incomplete setting for making AutolispExt ver1.5.0

##### Abstractions
A new setting was added within [PR138](https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/138). It's visible on VS Code, but it's not yet implemented.

We want to publish Autolisp Extension ver1.5.0, so we have to remove this setting first. After ver1.5.0 is published, I'll revert this PR to get it added back.

##### Tests performed


##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
