### PR TITLE
Revert PR 150

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
 					],
 					"default": "2022",
 					"description": "%autolispext.configuration.helptargetyear%"
+				},
+				"autolispext.completion.FilterMacOS": {
+					"type": "boolean",
+					"default": true,
+					"description": "%autolispext.configuration.macfilter.desc%"
 				}
 			}
 		},


### PR DESCRIPTION
Reverts Autodesk-AutoCAD/AutoLispExt#150.

With https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/150, in order to release v1.5.0, an incomplete work was temporarily reverted.

Since we have now published v1.5.0 to the market place, the reverted code can be added back.