### PR TITLE
Add 2023 as the default online help target year

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,9 +234,10 @@
 						"2019",
 						"2020",
 						"2021",
-						"2022"
+						"2022",
+						"2023"
 					],
-					"default": "2022",
+					"default": "2023",
 					"description": "%autolispext.configuration.helptargetyear%"
 				},
 				"autolispext.completion.FilterMacOS": {


### PR DESCRIPTION
##### Objective
This is to make it open online help with 2023 used as default target year.

##### Abstractions
<!-- How to do the changes, or the algorithm -->

##### Tests performed
It works as expected.

##### Screen shot
![image](https://user-images.githubusercontent.com/57521938/185305681-a7a9fd89-0689-4a0b-9774-7da714954ec2.png)
