### PR TITLE
Hide an incomplete setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,11 +239,6 @@
 					],
 					"default": "2023",
 					"description": "%autolispext.configuration.helptargetyear%"
-				},
-				"autolispext.completion.FilterMacOS": {
-					"type": "boolean",
-					"default": true,
-					"description": "%autolispext.configuration.macfilter.desc%"
 				}
 			}
 		},


### PR DESCRIPTION
##### Objective
Hide an incomplete setting by reverting Autodesk-AutoCAD/AutoLispExt#157

##### Abstractions
A new setting was added within [PR138](https://github.com/Autodesk-AutoCAD/AutoLispExt/pull/138). It's visible on VS Code, but it's not yet implemented.

We want to publish a new version of Autolisp Extension, so we have to remove this setting first. 
It can be added back by reverting this PR.

##### Tests performed


##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
