### PR TITLE
Make the localization identical on the DCL auto-completion UI

### DIFF
--- a/extension/src/completion/completionLibraryDcl.ts
+++ b/extension/src/completion/completionLibraryDcl.ts
@@ -77,8 +77,9 @@ export class CompletionLibraryDcl {
 
 	private generateDynamics() : void {
 		const localDialogStruct = localize("autolispext.commands.dclcompletion.primitive.dialog", "Generates a dialog structure");
+		const localTile = localize("autolispext.commands.dclcompletion.primitive.Tile", "Tile");
 		this.dclSnippets.set(SnippetKeys.DIALOG,
-			this.makeSnippet('dialog', localDialogStruct, 'Tile', `\${1:NAME} : dialog {\n\t$0\n}`, Kinds.TILE)
+			this.makeSnippet('dialog', localDialogStruct, localTile, `\${1:NAME} : dialog {\n\t$0\n}`, Kinds.TILE)
 		);
 
 		const localPrimitive = localize("autolispext.commands.dclcompletion.primitive", "Primitive");
@@ -113,7 +114,9 @@ export class CompletionLibraryDcl {
 	}
 
     private generateTiles() : void {
-        for (const key of AutoLispExt.WebHelpLibrary.dclTiles.keys()) {
+		const localTile = localize("autolispext.commands.dclcompletion.primitive.Tile", "Tile");
+
+		for (const key of AutoLispExt.WebHelpLibrary.dclTiles.keys()) {
 			const lowerKey = key.toLowerCase();
 			if (lowerKey === 'dialog') {
 				continue;
@@ -122,7 +125,7 @@ export class CompletionLibraryDcl {
             const def = AutoLispExt.WebHelpLibrary.dclTiles.get(key);
             const item = new CompletionItemDcl(def.id);
             item.kind = Kinds.TILE;
-			item.detail = 'Tile';
+			item.detail = localTile;
             item.sortText = `!${lowerKey}`; // The '!' helps elevate suggestions
             item.documentation = Annotation.asMarkdown(def);
 			item.insertText = def.id;
@@ -140,12 +143,14 @@ export class CompletionLibraryDcl {
 		// TODO: OS Filtering Technical debt
 		//       After the Lisp AutoComplete gets updated, then we can turn on the new setting for both document types.
 
+		const localAttr = localize("autolispext.commands.dclcompletion.primitive.Attribute", "Attribute");
+
         for (const key of AutoLispExt.WebHelpLibrary.dclAttributes.keys()) {
             const def = AutoLispExt.WebHelpLibrary.dclAttributes.get(key);
             const lowerKey = key.toLowerCase();
             const item = new CompletionItemDcl(def.id);
             item.kind = Kinds.ATTRIBUTE;
-			item.detail = 'Attribute';			
+			item.detail = localAttr;			
             item.sortText = `!!${lowerKey}`; // The '!!' helps elevate Attribute suggestions above Tile suggestions
             item.documentation = Annotation.asMarkdown(def);
 			item.insertText = def.id;
@@ -154,6 +159,8 @@ export class CompletionLibraryDcl {
     }
 
 	private generateEnums() : void {
+		const localEnum = localize("autolispext.commands.dclcompletion.primitive.Enum", "Enum");
+
 		for (const key of AutoLispExt.WebHelpLibrary.dclAttributes.keys()) {
 			const def = AutoLispExt.WebHelpLibrary.dclAttributes.get(key);
 			const lowerKey = key.toLowerCase();
@@ -173,7 +180,7 @@ export class CompletionLibraryDcl {
 				def.valueType.enums.forEach(name => {
 					const item = new CompletionItemDcl(name);
 					item.kind = Kinds.ENUM;
-					item.detail = 'Enum';
+					item.detail = localEnum;
 					item.sortText = name;
 					item.insertText = name;
 					types.push(item);

--- a/extension/src/completion/completionLibraryDcl.ts
+++ b/extension/src/completion/completionLibraryDcl.ts
@@ -143,7 +143,7 @@ export class CompletionLibraryDcl {
 		// TODO: OS Filtering Technical debt
 		//       After the Lisp AutoComplete gets updated, then we can turn on the new setting for both document types.
 
-		const localAttr = localize("autolispext.commands.dclcompletion.primitive.Attribute", "Attribute");
+        const localAttr = localize("autolispext.commands.dclcompletion.primitive.Attribute", "Attribute");
 
         for (const key of AutoLispExt.WebHelpLibrary.dclAttributes.keys()) {
             const def = AutoLispExt.WebHelpLibrary.dclAttributes.get(key);

--- a/extension/src/completion/completionLibraryDcl.ts
+++ b/extension/src/completion/completionLibraryDcl.ts
@@ -114,9 +114,9 @@ export class CompletionLibraryDcl {
 	}
 
     private generateTiles() : void {
-		const localTile = localize("autolispext.commands.dclcompletion.primitive.Tile", "Tile");
+        const localTile = localize("autolispext.commands.dclcompletion.primitive.Tile", "Tile");
 
-		for (const key of AutoLispExt.WebHelpLibrary.dclTiles.keys()) {
+        for (const key of AutoLispExt.WebHelpLibrary.dclTiles.keys()) {
 			const lowerKey = key.toLowerCase();
 			if (lowerKey === 'dialog') {
 				continue;

--- a/extension/src/completion/completionProviderDcl.ts
+++ b/extension/src/completion/completionProviderDcl.ts
@@ -109,7 +109,7 @@ function getApplicableAttributes(tile: DclTile, pos: Position) : Array<string> {
 function stringProcessing(atom: IDclFragment, directParent: IDclContainer, pos: Position, context: CompletionContext): Array<CompletionItemDcl> {
     const index = directParent.atoms.indexOf(atom);
     if (directParent.atoms[index + 1]?.symbol !== ';' && pos.character === atom.range.end.character - 1) {
-        const localPrimitive = localize("autolispext.commands.dclcompletion.primitive.Primitive", "Primitive");
+        const localPrimitive = localize("autolispext.commands.dclcompletion.primitive", "Primitive");
         const localClosesStr = localize("autolispext.commands.dclcompletion.primitive.ClosesString", "Closes the string");
         const result = new CompletionItemDcl(`${atom.symbol};`);
         result.insertText = `${atom.symbol};`;

--- a/extension/src/completion/completionProviderDcl.ts
+++ b/extension/src/completion/completionProviderDcl.ts
@@ -7,6 +7,10 @@ import {CompletionItemDcl} from "./completionItemDcl";
 import {AutoLispExt} from "../context";
 import {CompletionLibraryDcl, SnippetKeys} from "./completionLibraryDcl";
 import {Kinds} from './completionItemDcl';
+import * as nls from 'vscode-nls';
+
+const localize = nls.loadMessageBundle();
+
 
 // This file is responsible for determining what could potentially be suggested give the current context
 
@@ -105,10 +109,12 @@ function getApplicableAttributes(tile: DclTile, pos: Position) : Array<string> {
 function stringProcessing(atom: IDclFragment, directParent: IDclContainer, pos: Position, context: CompletionContext): Array<CompletionItemDcl> {
     const index = directParent.atoms.indexOf(atom);
     if (directParent.atoms[index + 1]?.symbol !== ';' && pos.character === atom.range.end.character - 1) {
+        const localPrimitive = localize("autolispext.commands.dclcompletion.primitive.Primitive", "Primitive");
+        const localClosesStr = localize("autolispext.commands.dclcompletion.primitive.ClosesString", "Closes the string");
         const result = new CompletionItemDcl(`${atom.symbol};`);
         result.insertText = `${atom.symbol};`;
-        result.detail = 'Primitive';
-        result.documentation = 'Closes the string';
+        result.detail = localPrimitive;
+        result.documentation = localClosesStr;
         result.range = atom.range;
         result.kind = Kinds.PRIMITIVE;
         return [result];

--- a/extension/src/completion/completionProviderDcl.ts
+++ b/extension/src/completion/completionProviderDcl.ts
@@ -109,8 +109,8 @@ function getApplicableAttributes(tile: DclTile, pos: Position) : Array<string> {
 function stringProcessing(atom: IDclFragment, directParent: IDclContainer, pos: Position, context: CompletionContext): Array<CompletionItemDcl> {
     const index = directParent.atoms.indexOf(atom);
     if (directParent.atoms[index + 1]?.symbol !== ';' && pos.character === atom.range.end.character - 1) {
-        const localPrimitive = localize("autolispext.commands.dclcompletion.primitive", "Primitive");
-        const localClosesStr = localize("autolispext.commands.dclcompletion.primitive.ClosesString", "Closes the string");
+        const localPrimitive = localize("autolispext.commands.dclcompletion.provider.Primitive", "Primitive");
+        const localClosesStr = localize("autolispext.commands.dclcompletion.provider.ClosesString", "Closes the string");
         const result = new CompletionItemDcl(`${atom.symbol};`);
         result.insertText = `${atom.symbol};`;
         result.detail = localPrimitive;

--- a/i18n/enu/out/completion/completionLibraryDcl.i18n.json
+++ b/i18n/enu/out/completion/completionLibraryDcl.i18n.json
@@ -6,6 +6,5 @@
   "autolispext.commands.dclcompletion.primitive.boolean": "boolean structure",
   "autolispext.commands.dclcompletion.primitive.Enum": "Enum",
   "autolispext.commands.dclcompletion.primitive.Attribute": "Attribute",
-  "autolispext.commands.dclcompletion.primitive.Tile": "Tile",
-  "autolispext.commands.dclcompletion.primitive.ClosesString": "Closes the string"
+  "autolispext.commands.dclcompletion.primitive.Tile": "Tile"
 }

--- a/i18n/enu/out/completion/completionLibraryDcl.i18n.json
+++ b/i18n/enu/out/completion/completionLibraryDcl.i18n.json
@@ -3,5 +3,9 @@
   "autolispext.commands.dclcompletion.primitive.dialog": "Generates a dialog structure",
   "autolispext.commands.dclcompletion.primitive.structure": "structural primitive",
   "autolispext.commands.dclcompletion.primitive.string": "string structure",
-  "autolispext.commands.dclcompletion.primitive.boolean": "boolean structure"
+  "autolispext.commands.dclcompletion.primitive.boolean": "boolean structure",
+  "autolispext.commands.dclcompletion.primitive.Enum": "Enum",
+	"autolispext.commands.dclcompletion.primitive.Attribute": "Attribute",
+  "autolispext.commands.dclcompletion.primitive.Tile": "Tile",
+  "autolispext.commands.dclcompletion.primitive.ClosesString": "Closes the string"
 }

--- a/i18n/enu/out/completion/completionLibraryDcl.i18n.json
+++ b/i18n/enu/out/completion/completionLibraryDcl.i18n.json
@@ -5,7 +5,7 @@
   "autolispext.commands.dclcompletion.primitive.string": "string structure",
   "autolispext.commands.dclcompletion.primitive.boolean": "boolean structure",
   "autolispext.commands.dclcompletion.primitive.Enum": "Enum",
-	"autolispext.commands.dclcompletion.primitive.Attribute": "Attribute",
+  "autolispext.commands.dclcompletion.primitive.Attribute": "Attribute",
   "autolispext.commands.dclcompletion.primitive.Tile": "Tile",
   "autolispext.commands.dclcompletion.primitive.ClosesString": "Closes the string"
 }

--- a/i18n/enu/out/completion/completionProviderDcl.i18n.json
+++ b/i18n/enu/out/completion/completionProviderDcl.i18n.json
@@ -1,0 +1,4 @@
+{
+  "autolispext.commands.dclcompletion.provider.Primitive": "Primitive",
+  "autolispext.commands.dclcompletion.provider.ClosesString": "Closes the string"
+}


### PR DESCRIPTION
##### Objective
Make the localization identical on the DCL auto-completion UI

##### Abstractions
It's noticed that the localization on the DCL auto-completion popup is not identical:
- sometimes it's fully localized
- sometimes its title is not localized
- sometimes it's not localized at all

This PR is to make the behavior identical - i.e. always fully localized.

##### Tests performed
The inconsistency found during testing is gone.

##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
