### PR TITLE
Moved acet-ui-progress to ambiguousFunctions

### DIFF
--- a/extension/src/help/webHelpAbstraction.json
+++ b/extension/src/help/webHelpAbstraction.json
@@ -9407,41 +9407,6 @@
       "description": "Displays a directory selection dialog",
       "platforms": "WIN"
     },
-    "acet-ui-progress": {
-      "arguments": [
-        {
-          "id": "label",
-          "typeNames": "String",
-          "primitive": "string",
-          "enums": []
-        },
-        {
-          "id": "max",
-          "typeNames": "Integer",
-          "primitive": "integer",
-          "enums": []
-        },
-        {
-          "id": "current",
-          "typeNames": "Integer",
-          "primitive": "integer",
-          "enums": []
-        }
-      ],
-      "returnType": {
-        "id": "Return",
-        "typeNames": "Integer, Boolean, nil",
-        "primitive": "integer",
-        "enums": []
-      },
-      "validObjects": [],
-      "signature": "(acet-ui-progress label?<string> max?<integer>) and (acet-ui-progress current<integer>)",
-      "id": "acet-ui-progress",
-      "category": 4,
-      "guid": "177D04DD-7822-4DFE-B9B6-92FC2B7A0697",
-      "description": "Displays a progress meter",
-      "platforms": "WIN"
-    },
     "acet-ui-status": {
       "arguments": [
         {
@@ -93921,6 +93886,76 @@
     }
   },
   "ambiguousFunctions": {
+    "acet-ui-progress": [
+      {
+        "arguments": [
+          {
+            "id": "label",
+            "typeNames": "String",
+            "primitive": "string",
+            "enums": []
+          },
+          {
+            "id": "max",
+            "typeNames": "Integer",
+            "primitive": "integer",
+            "enums": []
+          }
+        ],
+        "returnType": {
+          "id": "Return",
+          "typeNames": "Boolean, nil",
+          "primitive": "boolean",
+          "enums": []
+        },
+        "validObjects": [],
+        "signature": "(acet-ui-progress label?<string> max?<integer>)",
+        "id": "acet-ui-progress",
+        "category": 4,
+        "guid": "177D04DD-7822-4DFE-B9B6-92FC2B7A0697",
+        "description": "Displays a progress meter",
+        "platforms": "WIN"
+      },
+      {
+        "arguments": [
+          {
+            "id": "current",
+            "typeNames": "Integer",
+            "primitive": "integer",
+            "enums": []
+          }
+        ],
+        "returnType": {
+          "id": "Return",
+          "typeNames": "Integer",
+          "primitive": "integer",
+          "enums": []
+        },
+        "validObjects": [],
+        "signature": "(acet-ui-progress current<integer>)",
+        "id": "acet-ui-progress",
+        "category": 4,
+        "guid": "177D04DD-7822-4DFE-B9B6-92FC2B7A0697",
+        "description": "Displays a progress meter",
+        "platforms": "WIN"
+      },
+      {
+        "arguments": [],
+        "returnType": {
+          "id": "Return",
+          "typeNames": "nil",
+          "primitive": "nil",
+          "enums": []
+        },
+        "validObjects": [],
+        "signature": "(acet-ui-progress)",
+        "id": "acet-ui-progress",
+        "category": 4,
+        "guid": "177D04DD-7822-4DFE-B9B6-92FC2B7A0697",
+        "description": "Displays a progress meter",
+        "platforms": "WIN"
+      }
+    ],
     "getpropertyvalue": [
       {
         "arguments": [

--- a/extension/src/help/webHelpAbstraction.json
+++ b/extension/src/help/webHelpAbstraction.json
@@ -93952,7 +93952,7 @@
         "id": "acet-ui-progress",
         "category": 4,
         "guid": "177D04DD-7822-4DFE-B9B6-92FC2B7A0697",
-        "description": "Displays a progress meter",
+        "description": "Closes the progress meter",
         "platforms": "WIN"
       }
     ],


### PR DESCRIPTION
##### Objective
Move the documentation for the `acet-ui-progress` function to the **ambiguousFunctions** section of the help source file.

##### Abstractions
`acet-ui-progress` function was moved to the **ambiguousFunctions** section and the previous entry was expanded to support the three different signatures.

##### Tests performed
Test the changes in Visual Studio code.  All three signatures could be seen in the tooltip when hovering over the function name in the editor window.  Open Online Help was also tested for the function and worked as expected.

##### Screen shot
![image](https://user-images.githubusercontent.com/67277192/230405593-1c22ae7a-0cef-4b60-b75f-0248799f206b.png)

