### PR TITLE
Bump actions/upload-artifact to v4 to fix pipeline errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           python pack.py
 
       - name: Upload package-lock.json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: localFile
           path: package-lock.json


### PR DESCRIPTION
##### Objective
Fix pipeline errors:
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
##### Abstractions
The fix is to update actions/upload-artifact to v4, the recommended version by GitHub.

##### Tests performed


##### Screen shot
<!-- GIF screen shot is preferred, this helps reviewers and testers understand what's the behavior changed -->
